### PR TITLE
Remove attempt at mass creation of extension DB tables

### DIFF
--- a/_sources/canasta/CanastaDefaultSettings.php
+++ b/_sources/canasta/CanastaDefaultSettings.php
@@ -117,8 +117,6 @@ if ( $filenames !== false && is_array( $filenames ) ) {
 	}
 }
 
-require_once getenv( 'MW_HOME' ) . '/temp-extension-setup.php';
-
 # Include the FarmConfig
 if ( file_exists( getenv( 'MW_VOLUME' ) . '/config/wikis.yaml' ) ) {
 	require_once "$IP/FarmConfigLoader.php";

--- a/_sources/scripts/extensions-skins.php
+++ b/_sources/scripts/extensions-skins.php
@@ -15,7 +15,6 @@ $MW_VERSION = getenv("MW_VERSION");
 $MW_VOLUME = getenv("MW_VOLUME");
 $MW_ORIGIN_FILES = getenv("MW_ORIGIN_FILES");
 $path = $argv[1];
-$extensionsToEnable = [];
 
 $contentsData = [
     'extensions' => [],
@@ -83,35 +82,11 @@ foreach (['extensions', 'skins'] as $type) {
                 } elseif ($step === "git submodule update") {
                     $submoduleUpdateCmd = "cd $MW_HOME/$type/$name && git submodule update --init";
                     exec($submoduleUpdateCmd);
-                } elseif ($step === "database update") {
-                    if ($requiredExtensions !== null) {
-                        foreach ($requiredExtensions as $ext){
-                            if (!in_array($ext, $extensionsToEnable, true)) {
-                                $extensionsToEnable[] = $ext;
-                            }
-                        }
-                    }
-                    $extensionsToEnable[] = $name;
                 }
             }
         }
     }
 }
-
-$extensionsFile = getenv("MW_HOME") . "/temp-extension-setup.php";
-
-// Generate a temporary PHP file to enable extensions
-$extensionCode = "<?php\n";
-foreach ( $extensionsToEnable as $ext ) {
-    $extensionCode .= "wfLoadExtension('$ext');\n";
-}
-file_put_contents( $extensionsFile, $extensionCode );
-
-// Run update.php with extensions enabled
-exec( "MW_SETUP_MODE=true php $MW_HOME/maintenance/update.php" );
-
-// Reset extensions file to just "<?php"
-file_put_contents( $extensionsFile, "<?php" );
 
 /**
  * Recursive function to allow for loading a whole chain of YAML files (if


### PR DESCRIPTION
This was more challenging than we thought it would be, and would probably have to be done instead via a shell script like run-all.sh - right now it isn't working, so we'll just remove it. Maybe it can be done in the next version...