### PR TITLE
Update canasta_img.php to fix deprecated usage in favor of Canasta 1.43

### DIFF
--- a/_sources/canasta/canasta_img.php
+++ b/_sources/canasta/canasta_img.php
@@ -47,7 +47,7 @@ function wfImageAuthMain() {
 	$permissionManager = $services->getPermissionManager();
 
 	$request = RequestContext::getMain()->getRequest();
-	$publicWiki = in_array( 'read', $permissionManager->getGroupPermissions( [ '*' ] ), true );
+	$publicWiki = in_array( 'read', $services->getGroupPermissionsLookup()->getGroupPermissions( [ '*' ] ), true );
 
 	// Find the path assuming the request URL is relative to the local public zone URL
 	$baseUrl = $services->getRepoGroup()->getLocalRepo()->getZoneUrl( 'public' );


### PR DESCRIPTION
Replace PermissionManager::getGroupPermissions with GroupPermissionsLookup::getGroupPermissions due to deprecation since REL1_40