### PR TITLE
Remove setting of $wgJobRunRate to 0

### DIFF
--- a/_sources/canasta/CanastaDefaultSettings.php
+++ b/_sources/canasta/CanastaDefaultSettings.php
@@ -57,9 +57,6 @@ $wgResourceBasePath = $wgScriptPath;
 # SyntaxHighlight_GeSHi
 $wgPygmentizePath = '/usr/bin/pygmentize';
 
-# We use job runner instead
-$wgJobRunRate = 0;
-
 # SVG Converters
 $wgSVGConverter = 'rsvg';
 


### PR DESCRIPTION
The "job runner" mentioned in the comment no longer seems to run by default, which makes this a very bad setting to have - it means no jobs get run. Even if a job runner cron job does run, there's no harm to also having MediaWiki run jobs in its own way, I would think.