### PR TITLE
Two fixes for the creation of extension/skin symlinks

### DIFF
--- a/_sources/scripts/extensions-skins.php
+++ b/_sources/scripts/extensions-skins.php
@@ -69,8 +69,8 @@ foreach (['extensions', 'skins'] as $type) {
                 }
             }
 
-            $gitCloneCmd .= "$repository $MW_HOME/$type/$name";
-            $gitCheckoutCmd = "cd $MW_HOME/$type/$name && git checkout -q $commit";
+            $gitCloneCmd .= "$repository $MW_HOME/canasta-$type/$name";
+            $gitCheckoutCmd = "cd $MW_HOME/canasta-$type/$name && git checkout -q $commit";
 
             exec($gitCloneCmd);
             exec($gitCheckoutCmd);
@@ -78,7 +78,7 @@ foreach (['extensions', 'skins'] as $type) {
 
         if ($patches !== null) {
             foreach ($patches as $patch) {
-                $gitApplyCmd = "cd $MW_HOME/$type/$name && git apply /tmp/$patch";
+                $gitApplyCmd = "cd $MW_HOME/canasta-$type/$name && git apply /tmp/$patch";
                 exec($gitApplyCmd);
             }
         }
@@ -86,10 +86,10 @@ foreach (['extensions', 'skins'] as $type) {
         if ($additionalSteps !== null) {
             foreach ($additionalSteps as $step) {
                 if ($step === "composer update") {
-                    $composerInstallCmd = "composer install --working-dir=$MW_HOME/$type/$name --no-interaction --no-dev";
+                    $composerInstallCmd = "composer install --working-dir=$MW_HOME/canasta-$type/$name --no-interaction --no-dev";
                     shell_exec("$composerInstallCmd");
                 } elseif ($step === "git submodule update") {
-                    $submoduleUpdateCmd = "cd $MW_HOME/$type/$name && git submodule update --init";
+                    $submoduleUpdateCmd = "cd $MW_HOME/canasta-$type/$name && git submodule update --init";
                     exec($submoduleUpdateCmd);
                 }
             }

--- a/_sources/scripts/maintenance-scripts/monitor-directories.sh
+++ b/_sources/scripts/maintenance-scripts/monitor-directories.sh
@@ -15,23 +15,23 @@ canskins="$MW_HOME/canasta-skins"
 #    located in canasta-extensions.
 
 inotifywait -m -e create,moved_to,delete,moved_from --format '%e:%f' -- "$userexts" |
-	while IFS=: read -r event file; do
-		case $event in
-			CREATE,ISDIR|MOVED_TO,ISDIR)
-				ln -rsft "$extensions" -- "$userexts"/"$file" ;;
-			DELETE,ISDIR|MOVED_FROM,ISDIR)
-				echo "event: ${event} file: ${file}";
-				ln -rsft "$extensions" -- "$canexts"/"$file" || rm -- "$file";
-		esac
-	done
+  while IFS=: read -r event file; do
+    case $event in
+      CREATE,ISDIR|MOVED_TO,ISDIR)
+        ln -sfn -- "$userexts/$file" "$extensions/$file" ;;
+      DELETE,ISDIR|MOVED_FROM,ISDIR)
+        echo "event: ${event} file: ${file}";
+        ln -sfn -- "$canexts/$file" "$extensions/$file" || rm -f -- "$extensions/$file" ;
+    esac
+  done
 
 inotifywait -m -e create,moved_to,delete,moved_from --format '%e:%f' -- "$userskins" |
-	while IFS=: read -r event file; do
-		case $event in
-			CREATE,ISDIR|MOVED_TO,ISDIR)
-				ln -rsft "$skins" -- "$userskins"/"$file" ;;
-			DELETE,ISDIR|MOVED_FROM,ISDIR)
-				echo "event: ${event} file: ${file}";
-				ln -rsft "$skins" -- "$canskins"/"$file" || rm -- "$file";
-		esac
-	done
+  while IFS=: read -r event file; do
+    case $event in
+      CREATE,ISDIR|MOVED_TO,ISDIR)
+        ln -sfn -- "$userskins/$file" "$skins/$file" ;;
+      DELETE,ISDIR|MOVED_FROM,ISDIR)
+        echo "event: ${event} file: ${file}";
+        ln -sfn -- "$canskins/$file" "$skins/$file" || rm -f -- "$skins/$file" ;
+    esac
+  done


### PR DESCRIPTION
- Make every subdirectory in the canasta-extensions/ and canasta-skins/ directories be a symlink - in some cases, the actual directory ended up there, instead of a symlink to it (fixes #18)
- Replace relative symlinks with absolute symlinks