### PR TITLE
Fix label namespace from org.canasta to wiki.canasta

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,8 @@ ENV MW_VERSION=REL1_43 \
     WWW_GROUP=www-data \
     APACHE_LOG_DIR=/var/log/apache2
 
-LABEL org.canasta.mediawiki.version="$MW_CORE_VERSION" \
-      org.canasta.mediawiki.branch="$MW_VERSION"
+LABEL wiki.canasta.mediawiki.version="$MW_CORE_VERSION" \
+      wiki.canasta.mediawiki.branch="$MW_VERSION"
 
 # System setup
 RUN set x; \


### PR DESCRIPTION
Follow up to https://github.com/CanastaWiki/CanastaBase/pull/27

Issue reported in https://github.com/CanastaWiki/Canasta/pull/552