### PR TITLE
Remove "warning" when no wikis.yaml file

### DIFF
--- a/_sources/scripts/maintenance-scripts/mw_job_runner.sh
+++ b/_sources/scripts/maintenance-scripts/mw_job_runner.sh
@@ -51,8 +51,6 @@ if [ -f "$MW_VOLUME/config/wikis.yaml" ]; then
     done
 else
     # wikis.yaml file does not exist. Skip parsing and running specific wiki jobs.
-    echo "Warning: wikis.yaml does not exist. Running general jobs."
-    
     # Place your general (non-wiki-specific) job run commands here.
     php $RJ --type="enotifNotify"
     sleep 1


### PR DESCRIPTION
This isn't a problem, thus no need for a warning. Fixes #38 