### PR TITLE
Add php8.1-bcmath extension to fix ScrambleMapping test failure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,6 +70,7 @@ RUN set x; \
 	php8.1-fpm \
 	php8.1-yaml \
 	php8.1-ldap \
+	php8.1-bcmath \
 	libapache2-mod-fcgid \
 	&& aptitude clean \
 	&& rm -rf /var/lib/apt/lists/*
@@ -104,7 +105,7 @@ RUN set -x; \
     && echo "postfix postfix/mailname string $LOCAL_SMTP_MAILNAME" | debconf-set-selections \
 	&& apt-get update \
 	&& apt-get install -y mailutils \
-	&& apt install -y postfix 
+	&& apt install -y postfix
 
 COPY main.cf /etc/postfix/main.cf
 
@@ -212,7 +213,7 @@ COPY _sources/configs/.htaccess $WWW_ROOT/
 COPY _sources/images/favicon.ico $WWW_ROOT/
 COPY _sources/canasta/LocalSettings.php _sources/canasta/CanastaUtils.php _sources/canasta/CanastaDefaultSettings.php _sources/canasta/FarmConfigLoader.php $MW_HOME/
 COPY _sources/canasta/getMediawikiSettings.php /
-COPY _sources/canasta/canasta_img.php $MW_HOME/ 
+COPY _sources/canasta/canasta_img.php $MW_HOME/
 COPY _sources/configs/mpm_event.conf /etc/apache2/mods-available/mpm_event.conf
 
 RUN set -x; \


### PR DESCRIPTION
This PR fixes a PHPUnit test failure in the CI pipeline by adding the `php8.1-bcmath` extension to the Dockerfile.

## Problem
The MediaWiki 1.43 `ScrambleMapping` class requires either the `bcmath` or `gmp` PHP extension. The current Dockerfile was missing both extensions, causing this PHPUnit test error:

```
MediaWiki\Tests\User\TempUser\ScrambleMappingTest::testOffsetTooLarge
RuntimeException: MediaWiki\User\TempUser\ScrambleMapping requires the bcmath or gmp extension
```

## Solution
Added `php8.1-bcmath` to the list of PHP extensions installed in the Docker image. The `bcmath` extension provides arbitrary-precision mathematics functions needed by the ScrambleMapping class.

## Testing
This change will be tested by the existing CI pipeline which runs PHPUnit tests against MediaWiki core.