### PR TITLE
Include port in $wgServer when running on non-standard ports

### DIFF
--- a/_sources/canasta/FarmConfigLoader.php
+++ b/_sources/canasta/FarmConfigLoader.php
@@ -26,6 +26,10 @@ if ( $urlComponents === false ) {
 // Extract the server name (host) from the URL
 if ( isset( $urlComponents['host'] ) ) {
 	$serverName = $urlComponents['host'];
+	// Include port if present
+	if ( isset( $urlComponents['port'] ) ) {
+		$serverName .= ':' . $urlComponents['port'];
+	}
 }
 
 // Extract the path from the URL, if any


### PR DESCRIPTION
## Summary
- Fix FarmConfigLoader.php to include the port number in `$wgServer` when running on non-standard ports

## Problem
When running a wiki farm on a non-standard port (e.g., 8443 instead of 443), `FarmConfigLoader.php` was extracting only the hostname from the request URL using `parse_url()`, discarding the port number. This caused `$wgServer` to be set incorrectly (e.g., `https://localhost` instead of `https://localhost:8443`), resulting in:
- Broken redirects (e.g., root URL redirecting to wrong port)
- Incorrect URLs throughout the wiki

## Solution
This fix checks for the presence of a port in the parsed URL components and appends it to the server name when present:

```php
if ( isset( $urlComponents['host'] ) ) {
    $serverName = $urlComponents['host'];
    // Include port if present
    if ( isset( $urlComponents['port'] ) ) {
        $serverName .= ':' . $urlComponents['port'];
    }
}
```

## Usage
Users running on non-standard ports must also update their `wikis.yaml` to include the port in the url field:
```yaml
wikis:
- id: wiki1
  url: localhost:8443  # Include port here
  name: wiki1
```

## Related PR
- See also: CanastaWiki/Canasta-DockerCompose#72 - Makes HTTP_PORT configurable to allow running multiple instances on different ports