### PR TITLE
Fix user extension/skin symlinks not overriding bundled ones

### DIFF
--- a/_sources/scripts/create-symlinks.sh
+++ b/_sources/scripts/create-symlinks.sh
@@ -18,12 +18,12 @@ echo "Symlinking user extensions and overwriting any redundant bundled extension
 for user_extension_path in $(find $MW_HOME/user-extensions/ -maxdepth 1 -mindepth 1 \( -type d -o -type l \))
 do
   user_extension_id=$(basename $user_extension_path)
-  ln -sf $MW_HOME/user-extensions/$user_extension_id/ $MW_HOME/extensions/$user_extension_id
+  ln -sfn $MW_HOME/user-extensions/$user_extension_id/ $MW_HOME/extensions/$user_extension_id
 done
 
 echo "Symlinking user skins and overwriting any redundant bundled skins..."
 for user_skin_path in $(find $MW_HOME/user-skins/ -maxdepth 1 -mindepth 1 \( -type d -o -type l \))
 do
   user_skin_id=$(basename $user_skin_path)
-  ln -sf $MW_HOME/user-skins/$user_skin_id/ $MW_HOME/skins/$user_skin_id
+  ln -sfn $MW_HOME/user-skins/$user_skin_id/ $MW_HOME/skins/$user_skin_id
 done


### PR DESCRIPTION
When a user extension or skin has the same name as a bundled one, the symlink in extensions/ or skins/ should point to the user version.

The `ln -sf` command follows existing symlinks, so when the target is already a symlink to a directory, it creates a nested symlink inside that directory instead of replacing it.

Using `ln -sfn` (the -n flag) treats the destination as a normal file, correctly replacing the existing symlink.