### PR TITLE
Remove Vector skin loading from CanastaDefaultSettings.php

### DIFF
--- a/_sources/canasta/CanastaDefaultSettings.php
+++ b/_sources/canasta/CanastaDefaultSettings.php
@@ -104,10 +104,6 @@ $wgDBTableOptions = "ENGINE=InnoDB, DEFAULT CHARSET=binary";
 $wgMainCacheType = CACHE_ACCEL;
 $wgMemCachedServers = [];
 
-# Default skin
-$wgDefaultSkin = "vector-2022";
-wfLoadSkin( 'Vector' );
-
 # Docker specific setup
 # Exclude all private IP ranges
 # see https://www.mediawiki.org/wiki/Manual:$wgCdnServersNoPurge


### PR DESCRIPTION
## Summary

Remove `$wgDefaultSkin` and `wfLoadSkin('Vector')` from CanastaDefaultSettings.php. These belong in the user-configurable `config/settings/global/30-Vector.php` so users can easily change or remove the default skin.

## Related PRs

- CanastaWiki/Canasta-DockerCompose#78 - Add `$wgDefaultSkin` to 30-Vector.php

## Merge Order

Both PRs should be merged together. Merging CanastaBase first would result in no default skin until the DockerCompose change is deployed.