### PR TITLE
Configure Varnish cache purging

### DIFF
--- a/_sources/canasta/CanastaDefaultSettings.php
+++ b/_sources/canasta/CanastaDefaultSettings.php
@@ -113,6 +113,10 @@ $wgCdnServersNoPurge[] = '10.0.0.0/8';     // 10.0.0.0 – 10.255.255.255
 $wgCdnServersNoPurge[] = '172.16.0.0/12';  // 172.16.0.0 – 172.31.255.255
 $wgCdnServersNoPurge[] = '192.168.0.0/16'; // 192.168.0.0 – 192.168.255.255
 
+# Configure Varnish cache purging
+$wgCdnServers = [ 'varnish:80' ];
+$wgInternalServer = preg_replace( '/^https:/', 'http:', $wgServer );
+
 /**
  * Returns boolean value from environment variable
  * Must return the same result as isTrue function in run-apache.sh file


### PR DESCRIPTION
## Summary
- Add `$wgCdnServers` and `$wgInternalServer` to enable MediaWiki to send PURGE requests to Varnish

## Problem
Without `$wgCdnServers` set, MediaWiki doesn't send PURGE requests to Varnish when pages are edited. This causes anonymous users to see stale cached content for up to 48 hours (the default Varnish TTL configured in `default.vcl`).

Logged-in users don't notice because the Varnish VCL bypasses caching for requests with session cookies.

## Solution
- `$wgCdnServers = [ 'varnish:80' ]` — tells MediaWiki where to send PURGE requests
- `$wgInternalServer = preg_replace( '/^https:/', 'http:', $wgServer )` — ensures the Host header in PURGE requests matches the cached content's hostname, using HTTP since Varnish listens internally on port 80

## Test plan
- [x] Edit a page while logged in
- [x] View the page in an incognito/private window (anonymous user)
- [x] Verify the edit appears immediately (without needing a hard refresh)

Fixes CanastaWiki/Canasta#252