### PR TITLE
Use /server-status for health check instead of MediaWiki API

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -262,6 +262,6 @@ EXPOSE 80
 WORKDIR $MW_HOME
 
 HEALTHCHECK --interval=1m --timeout=10s \
-	CMD wget -q --method=HEAD localhost/w/api.php
+	CMD wget -q --method=HEAD localhost/server-status
 
 CMD ["/run-all.sh"]


### PR DESCRIPTION
## Summary

- Change Docker HEALTHCHECK from `localhost/w/api.php` to `localhost/server-status`
- In wiki farm installations, the API endpoint fails because `FarmConfigLoader.php` can't resolve `localhost` in the `urlToWikiIdMap`, causing the container to report as `unhealthy` even though MediaWiki works fine
- `/server-status` is already configured for localhost access in Apache and doesn't involve MediaWiki at all

## Test plan

- [ ] Verify single-wiki installation reports healthy
- [ ] Verify wiki farm installation reports healthy
- [ ] Verify unhealthy container (Apache down) is correctly detected

Closes #68