### PR TITLE
Add public_assets directory for publicly accessible wiki files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -168,9 +168,10 @@ RUN set -x; \
     && chmod g+w -R $MW_HOME/canasta-extensions \
     && chown $WWW_USER:$WWW_GROUP -R $MW_HOME/canasta-skins \
     && chmod g+w -R $MW_HOME/canasta-skins \
-    # Create symlinks from $MW_VOLUME to the wiki root for images and cache directories
+    # Create symlinks from $MW_VOLUME to the wiki root for images, cache, and public_assets directories
     && ln -s $MW_VOLUME/images $MW_HOME/images \
-    && ln -s $MW_VOLUME/cache $MW_HOME/cache
+    && ln -s $MW_VOLUME/cache $MW_HOME/cache \
+    && ln -s $MW_VOLUME/public_assets $MW_HOME/public_assets
 
 # Create place where extensions and skins symlinks will live
 RUN set -x; \
@@ -231,7 +232,7 @@ COPY _sources/configs/.htaccess $WWW_ROOT/
 COPY _sources/images/favicon.ico $WWW_ROOT/
 COPY _sources/canasta/LocalSettings.php _sources/canasta/CanastaUtils.php _sources/canasta/CanastaDefaultSettings.php _sources/canasta/FarmConfigLoader.php $MW_HOME/
 COPY _sources/canasta/getMediawikiSettings.php /
-COPY _sources/canasta/canasta_img.php $MW_HOME/
+COPY _sources/canasta/canasta_img.php _sources/canasta/public_assets.php $MW_HOME/
 COPY _sources/configs/mpm_event.conf /etc/apache2/mods-available/mpm_event.conf
 
 RUN set -x; \
@@ -251,6 +252,8 @@ RUN set -x; \
 	&& sed -i '/<Directory \/var\/www\/>/i RewriteCond %{THE_REQUEST} \\s(.*?)\\s\nRewriteRule ^ - [E=ORIGINAL_URL:%{REQUEST_SCHEME}://%{HTTP_HOST}%1]' /etc/apache2/apache2.conf \
 	&& echo "Alias /w/images/ /var/www/mediawiki/w/canasta_img.php/" >> /etc/apache2/apache2.conf \
     && echo "Alias /w/images /var/www/mediawiki/w/canasta_img.php" >> /etc/apache2/apache2.conf \
+	&& echo "Alias /public_assets/ /var/www/mediawiki/w/public_assets.php/" >> /etc/apache2/apache2.conf \
+	&& echo "Alias /public_assets /var/www/mediawiki/w/public_assets.php" >> /etc/apache2/apache2.conf \
 	&& a2enmod expires remoteip\
 	&& a2disconf other-vhosts-access-log \
 	# Enable environment variables for FPM workers

--- a/_sources/canasta/public_assets.php
+++ b/_sources/canasta/public_assets.php
@@ -1,0 +1,130 @@
+<?php
+/**
+ * Public assets server for Canasta wiki farms.
+ *
+ * Serves files from /mediawiki/public_assets/{wiki_id}/ without authentication.
+ * Use for logos and other assets that should be publicly accessible on both
+ * public and private wikis.
+ *
+ * Unlike canasta_img.php, this script does not require MediaWiki bootstrap,
+ * making it faster for serving static assets.
+ *
+ * @file
+ * @ingroup entrypoint
+ */
+
+$configPath = '/mediawiki/config/wikis.yaml';
+
+// Parse request path
+$requestUri = $_SERVER['REQUEST_URI'] ?? '';
+
+// Handle subdir wikis: /wiki1/public_assets/... -> extract wiki1
+// For domain-based wikis: /public_assets/...
+$pathParts = explode( '/public_assets', $requestUri, 2 );
+$subdir = trim( $pathParts[0], '/' );
+$filePath = $pathParts[1] ?? '';
+
+// Remove query string from file path if present
+if ( ( $queryPos = strpos( $filePath, '?' ) ) !== false ) {
+    $filePath = substr( $filePath, 0, $queryPos );
+}
+
+// Determine wiki ID from wikis.yaml
+$wikiId = null;
+if ( file_exists( $configPath ) ) {
+    $config = yaml_parse_file( $configPath );
+    if ( isset( $config['wikis'] ) ) {
+        $serverName = $_SERVER['HTTP_HOST'] ?? 'localhost';
+        // Remove port from server name for matching
+        $serverNameNoPort = preg_replace( '/:.*$/', '', $serverName );
+
+        foreach ( $config['wikis'] as $wiki ) {
+            $wikiUrl = $wiki['url'] ?? '';
+            // Remove port from wiki URL for matching
+            $wikiUrlNoPort = preg_replace( '/:.*$/', '', $wikiUrl );
+
+            if ( !empty( $subdir ) ) {
+                // Subdir wiki: match domain/path
+                if ( $wikiUrl === "$serverName/$subdir" ||
+                     $wikiUrl === "$serverNameNoPort/$subdir" ||
+                     $wikiUrlNoPort === "$serverNameNoPort/$subdir" ) {
+                    $wikiId = $wiki['id'];
+                    break;
+                }
+            } else {
+                // Domain-based wiki: match domain (with or without port)
+                if ( $wikiUrl === $serverName ||
+                     $wikiUrl === $serverNameNoPort ||
+                     $wikiUrlNoPort === $serverName ||
+                     $wikiUrlNoPort === $serverNameNoPort ) {
+                    $wikiId = $wiki['id'];
+                    break;
+                }
+            }
+        }
+    }
+}
+
+if ( !$wikiId ) {
+    http_response_code( 404 );
+    echo "Wiki not found";
+    exit;
+}
+
+// Build full file path
+$assetsBaseDir = "/mediawiki/public_assets/$wikiId";
+$fullPath = $assetsBaseDir . $filePath;
+
+// Security: prevent directory traversal
+$realPath = realpath( $fullPath );
+$assetsDir = realpath( $assetsBaseDir );
+
+if ( $realPath === false || $assetsDir === false || strpos( $realPath, $assetsDir ) !== 0 ) {
+    http_response_code( 404 );
+    echo "File not found";
+    exit;
+}
+
+if ( !is_file( $realPath ) ) {
+    http_response_code( 404 );
+    echo "File not found";
+    exit;
+}
+
+// Determine content type
+$mimeTypes = [
+    'png' => 'image/png',
+    'jpg' => 'image/jpeg',
+    'jpeg' => 'image/jpeg',
+    'gif' => 'image/gif',
+    'svg' => 'image/svg+xml',
+    'ico' => 'image/x-icon',
+    'webp' => 'image/webp',
+    'css' => 'text/css',
+    'js' => 'application/javascript',
+    'json' => 'application/json',
+    'woff' => 'font/woff',
+    'woff2' => 'font/woff2',
+    'ttf' => 'font/ttf',
+    'otf' => 'font/otf',
+    'eot' => 'application/vnd.ms-fontobject',
+];
+$ext = strtolower( pathinfo( $realPath, PATHINFO_EXTENSION ) );
+$contentType = $mimeTypes[$ext] ?? 'application/octet-stream';
+
+// Serve file with public caching headers
+header( 'Content-Type: ' . $contentType );
+header( 'Content-Length: ' . filesize( $realPath ) );
+header( 'Cache-Control: public, max-age=86400' ); // 24 hours
+header( 'Last-Modified: ' . gmdate( 'D, d M Y H:i:s', filemtime( $realPath ) ) . ' GMT' );
+
+// Handle If-Modified-Since for conditional requests
+if ( isset( $_SERVER['HTTP_IF_MODIFIED_SINCE'] ) ) {
+    $ifModifiedSince = strtotime( $_SERVER['HTTP_IF_MODIFIED_SINCE'] );
+    if ( $ifModifiedSince !== false && filemtime( $realPath ) <= $ifModifiedSince ) {
+        http_response_code( 304 );
+        exit;
+    }
+}
+
+readfile( $realPath );

--- a/_sources/configs/.htaccess
+++ b/_sources/configs/.htaccess
@@ -12,6 +12,9 @@ RewriteRule ^/?w/rest.php/ - [L]
 # Redirects requests to canasta_img.php for handling image authorization in Canasta.
 RewriteRule ^/?w/canasta_img.php/ - [L]
 
+# Redirects requests to public_assets.php for serving public assets in Canasta.
+RewriteRule ^/?w/public_assets.php/ - [L]
+
 # Redirect / to Main Page
 RewriteRule ^/*$ %{DOCUMENT_ROOT}/w/index.php [L]
 

--- a/_sources/scripts/config-subdir-wikis.sh
+++ b/_sources/scripts/config-subdir-wikis.sh
@@ -21,6 +21,7 @@ for path in $wiki_paths; do
     # Modify .htaccess file
     sed -e "s|w/rest.php/|$path/w/rest.php/|g" \
     -e "s|w/canasta_img.php/|$path/w/canasta_img.php/|g" \
+    -e "s|w/public_assets.php/|$path/w/public_assets.php/|g" \
     -e "s|^/*$ %{DOCUMENT_ROOT}/w/index.php|/*$ %{DOCUMENT_ROOT}/$path/w/index.php|" \
     -e "s|^\\(.*\\)$ %{DOCUMENT_ROOT}/w/index.php|\\1$ %{DOCUMENT_ROOT}/$path/w/index.php|" \
     $WWW_ROOT/.htaccess > $WWW_ROOT/$path/.htaccess
@@ -28,5 +29,9 @@ for path in $wiki_paths; do
     # Modify apache2.conf file for canasta_img.php
     echo "Alias /$path/w/images/ /var/www/mediawiki/w/canasta_img.php/" >> /etc/apache2/apache2.conf
     echo "Alias /$path/w/images /var/www/mediawiki/w/canasta_img.php" >> /etc/apache2/apache2.conf
+
+    # Modify apache2.conf file for public_assets.php
+    echo "Alias /$path/public_assets/ /var/www/mediawiki/w/public_assets.php/" >> /etc/apache2/apache2.conf
+    echo "Alias /$path/public_assets /var/www/mediawiki/w/public_assets.php" >> /etc/apache2/apache2.conf
   fi
 done

--- a/_sources/scripts/create-storage-dirs.sh
+++ b/_sources/scripts/create-storage-dirs.sh
@@ -8,13 +8,15 @@ readarray -t ids <<< "$wiki_ids"
 
 # Loop through the ids
 for db_name in "${ids[@]}"; do
-    # Create the cache and images directories if they don't exist
+    # Create the cache, images, and public_assets directories if they don't exist
     mkdir -p $MW_VOLUME/cache/$db_name
     mkdir -p $MW_VOLUME/images/$db_name
+    mkdir -p $MW_VOLUME/public_assets/$db_name
 
     # Change the permissions of these directories
     chown -R $WWW_USER:$WWW_GROUP $MW_VOLUME/cache/$db_name
     chown -R $WWW_USER:$WWW_GROUP $MW_VOLUME/images/$db_name
+    chown -R $WWW_USER:$WWW_GROUP $MW_VOLUME/public_assets/$db_name
 done
 
 # Protect Images Directory from Internet Access

--- a/_sources/scripts/run-all.sh
+++ b/_sources/scripts/run-all.sh
@@ -60,9 +60,9 @@ config_subdir_wikis() {
 }
 
 create_storage_dirs() {
-    echo "Creating cache and images dirs..."
+    echo "Creating cache, images, and public_assets dirs..."
     /create-storage-dirs.sh
-    echo "Created cache and images dirs..."
+    echo "Created cache, images, and public_assets dirs..."
 }
 
 check_mount_points () {
@@ -90,6 +90,12 @@ cd "$MW_HOME" || exit
 /update-images-permissions.sh &
 
 ########## Run maintenance scripts ##########
+# Create storage directories early (before LocalSettings check) since wikis.yaml
+# exists before install.php runs, and we need these directories to exist for uploads
+if [ -e "$MW_VOLUME/config/wikis.yaml" ]; then
+  create_storage_dirs
+fi
+
 echo "Checking for LocalSettings..."
 if [ -e "$MW_VOLUME/config/LocalSettings.php" ] || [ -e "$MW_VOLUME/config/CommonSettings.php" ]; then
   # Run auto-update
@@ -97,7 +103,6 @@ if [ -e "$MW_VOLUME/config/LocalSettings.php" ] || [ -e "$MW_VOLUME/config/Commo
   run_autoupdate
   if [ -e "$MW_VOLUME/config/wikis.yaml" ]; then
     config_subdir_wikis
-    create_storage_dirs
   fi
 fi
 


### PR DESCRIPTION
## Summary

- Add `public_assets.php` script to serve files without authentication
- Add Apache aliases and symlink for `/public_assets` routing
- Update `create-storage-dirs.sh` to create `public_assets/{wiki-id}/` directories
- Update `config-subdir-wikis.sh` for subdir wiki support
- Fix `create-storage-dirs.sh` not running on fresh installs

Closes #70

## Related PRs

- CanastaWiki/Canasta-DockerCompose#87
- CanastaWiki/Canasta-CLI#207

## Test plan

- [x] Create installation with `--build-from` pointing to local repos
- [x] Verify `public_assets/{wiki-id}/` directory is created automatically at startup
- [x] Place a logo file and verify it's served at `/public_assets/logo.png`
- [x] Verify correct headers: `Cache-Control: public, max-age=86400`
- [x] Test 404 for non-existent files
- [x] Test subdir wiki routing (`/{path}/public_assets/logo.png`)