### PR TITLE
Upgrade PHP 8.1 to PHP 8.2 and enable LuaSandbox for Scribunto

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,27 +50,23 @@ RUN set x; \
 	rsync \
 	lynx \
 	poppler-utils \
-	&& wget -O /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg \
-	&& echo "deb https://packages.sury.org/php/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/php.list \
-	&& aptitude update \
-	&& aptitude install -y \
-	php8.1 \
-	php8.1-mysql \
-	php8.1-cli \
-	php8.1-gd \
-	php8.1-mbstring \
-	php8.1-xml \
-	php8.1-mysql \
-	php8.1-intl \
-	php8.1-opcache \
-	php8.1-apcu \
-	php8.1-redis \
-	php8.1-curl \
-	php8.1-zip \
-	php8.1-fpm \
-	php8.1-yaml \
-	php8.1-ldap \
-	php8.1-bcmath \
+	php \
+	php-mysql \
+	php-cli \
+	php-gd \
+	php-mbstring \
+	php-xml \
+	php-intl \
+	php-opcache \
+	php-apcu \
+	php-redis \
+	php-curl \
+	php-zip \
+	php8.2-fpm \
+	php-yaml \
+	php-ldap \
+	php-bcmath \
+	php-luasandbox \
 	libapache2-mod-fcgid \
 	&& aptitude clean \
 	&& rm -rf /var/lib/apt/lists/*
@@ -85,7 +81,7 @@ RUN set -x; \
     && a2enmod rewrite \
 	# enabling mpm_event and php-fpm
 	&& a2dismod mpm_prefork \
-	&& a2enconf php8.1-fpm \
+	&& a2enconf php8.2-fpm \
 	&& a2enmod mpm_event \
 	&& a2enmod proxy_fcgi \
     # Create directories
@@ -217,11 +213,11 @@ ENV MW_AUTOUPDATE=true \
 COPY _sources/configs/msmtprc /etc/
 COPY _sources/configs/mediawiki.conf /etc/apache2/sites-enabled/
 COPY _sources/configs/status.conf /etc/apache2/mods-available/
-COPY _sources/configs/php_error_reporting.ini _sources/configs/php_upload_max_filesize.ini /etc/php/8.1/cli/conf.d/
-COPY _sources/configs/php_error_reporting.ini _sources/configs/php_upload_max_filesize.ini /etc/php/8.1/fpm/conf.d/
-COPY _sources/configs/php_max_input_vars.ini _sources/configs/php_max_input_vars.ini /etc/php/8.1/fpm/conf.d/
-COPY _sources/configs/php_timeouts.ini /etc/php/8.1/fpm/conf.d/
-COPY _sources/configs/php-fpm-www.conf /etc/php/8.1/fpm/pool.d/www.conf
+COPY _sources/configs/php_error_reporting.ini _sources/configs/php_upload_max_filesize.ini /etc/php/8.2/cli/conf.d/
+COPY _sources/configs/php_error_reporting.ini _sources/configs/php_upload_max_filesize.ini /etc/php/8.2/fpm/conf.d/
+COPY _sources/configs/php_max_input_vars.ini _sources/configs/php_max_input_vars.ini /etc/php/8.2/fpm/conf.d/
+COPY _sources/configs/php_timeouts.ini /etc/php/8.2/fpm/conf.d/
+COPY _sources/configs/php-fpm-www.conf /etc/php/8.2/fpm/pool.d/www.conf
 COPY _sources/scripts/*.sh /
 COPY _sources/scripts/maintenance-scripts/*.sh /maintenance-scripts/
 COPY _sources/scripts/*.php $MW_HOME/maintenance/
@@ -254,7 +250,7 @@ RUN set -x; \
 	&& a2enmod expires remoteip\
 	&& a2disconf other-vhosts-access-log \
 	# Enable environment variables for FPM workers
-	&& sed -i '/clear_env/s/^;//' /etc/php/8.1/fpm/pool.d/www.conf
+	&& sed -i '/clear_env/s/^;//' /etc/php/8.2/fpm/pool.d/www.conf
 
 COPY _sources/images/Powered-by-Canasta.png /var/www/mediawiki/w/resources/assets/
 

--- a/_sources/canasta/CanastaDefaultSettings.php
+++ b/_sources/canasta/CanastaDefaultSettings.php
@@ -82,10 +82,6 @@ $wgPingback = false;
 # Use local files instead of Wikimedia Commons
 $wgUseInstantCommons = false;
 
-# Scribunto: use LuaSandbox for better performance
-# LuaSandbox is a PHP extension that provides a sandboxed Lua environment
-$wgScribuntoDefaultEngine = 'luasandbox';
-
 # Database connection (from environment, can be overridden by config/LocalSettings.php)
 $wgDBtype = "mysql";
 $wgDBserver = "db";

--- a/_sources/canasta/CanastaDefaultSettings.php
+++ b/_sources/canasta/CanastaDefaultSettings.php
@@ -82,6 +82,10 @@ $wgPingback = false;
 # Use local files instead of Wikimedia Commons
 $wgUseInstantCommons = false;
 
+# Scribunto: use LuaSandbox for better performance
+# LuaSandbox is a PHP extension that provides a sandboxed Lua environment
+$wgScribuntoDefaultEngine = 'luasandbox';
+
 # Database connection (from environment, can be overridden by config/LocalSettings.php)
 $wgDBtype = "mysql";
 $wgDBserver = "db";

--- a/_sources/configs/php-fpm-www.conf
+++ b/_sources/configs/php-fpm-www.conf
@@ -33,7 +33,7 @@ group = "${WWW_GROUP}"
 ;                            (IPv6 and IPv4-mapped) on a specific port;
 ;   '/path/to/unix/socket' - to listen on a unix socket.
 ; Note: This value is mandatory.
-listen = /run/php/php8.1-fpm.sock
+listen = /run/php/php8.2-fpm.sock
 
 ; Set listen(2) backlog.
 ; Default Value: 511 (-1 on FreeBSD and OpenBSD)

--- a/_sources/scripts/run-php-fpm.sh
+++ b/_sources/scripts/run-php-fpm.sh
@@ -5,4 +5,4 @@ set -x
 echo "starting php-fpm"
 # Running php-fpm
 mkdir -p /run/php
-exec /usr/sbin/php-fpm8.1
+exec /usr/sbin/php-fpm8.2


### PR DESCRIPTION
## Summary

- Remove sury.org third-party repository dependency
- Use Debian 12's native PHP 8.2 packages
- Add `php-luasandbox` package (available for users who want to enable it)
- Update php-fpm socket path and binary to 8.2

Closes #72

## Why?

1. **Simpler Dockerfile**: No external repository dependency
2. **LuaSandbox available**: Debian 12's native `php-luasandbox` works with PHP 8.2
3. **Future-proof**: MediaWiki 1.45+ requires PHP 8.2 minimum
4. **Longer support**: PHP 8.2 security support extends to December 2026

See #72 for full trade-off analysis.

## LuaSandbox

The `php-luasandbox` extension is installed and available. Users can enable it by adding to their LocalSettings.php:

```php
$wgScribuntoDefaultEngine = 'luasandbox';
```

The default remains `luastandalone` for compatibility.

## Test plan

- [x] Create test installation with `--build-from`
- [x] Enable Scribunto
- [x] Verify luasandbox on Special:Version
- [x] Verify no PHP errors in logs