### PR TITLE
Set public_assets directory ownership to match parent

### DIFF
--- a/_sources/scripts/create-storage-dirs.sh
+++ b/_sources/scripts/create-storage-dirs.sh
@@ -16,7 +16,7 @@ for db_name in "${ids[@]}"; do
     # Change the permissions of these directories
     chown -R $WWW_USER:$WWW_GROUP $MW_VOLUME/cache/$db_name
     chown -R $WWW_USER:$WWW_GROUP $MW_VOLUME/images/$db_name
-    chown -R $WWW_USER:$WWW_GROUP $MW_VOLUME/public_assets/$db_name
+    chown $(stat -c '%u' $MW_VOLUME/public_assets):$WWW_GROUP $MW_VOLUME/public_assets/$db_name
 done
 
 # Protect Images Directory from Internet Access


### PR DESCRIPTION
## Summary

- Set `public_assets/{wiki-id}` owner to match parent directory (host user)
- Keep `www-data` as group for container read access
- Allows host user to write files directly without sudo

Fixes #74