### PR TITLE
Fix $wgMetaNamespace for wiki names containing spaces

### DIFF
--- a/_sources/canasta/FarmConfigLoader.php
+++ b/_sources/canasta/FarmConfigLoader.php
@@ -155,9 +155,10 @@ if ( !empty( $selectedWikiConfig ) ) {
 	// Set database name to the wiki ID
 	$wgDBname = $wikiID;
 
-	// Set site name and meta namespace from the configuration, or use the wiki ID if 'name' is not set
+	// Set site name from the configuration, or use the wiki ID if 'name' is not set
 	$wgSitename = isset( $selectedWikiConfig['name'] ) ? $selectedWikiConfig['name'] : $wikiID;
-	$wgMetaNamespace = isset( $selectedWikiConfig['name'] ) ? $selectedWikiConfig['name'] : $wikiID;
+	// Set meta namespace from site name with spaces replaced by underscores (required for valid namespace names)
+	$wgMetaNamespace = str_replace( ' ', '_', $wgSitename );
 } else {
 	die( 'Unknown wiki.' );
 }


### PR DESCRIPTION
## Summary

`$wgMetaNamespace` was set to the same value as `$wgSitename` (the wiki display name from `wikis.yaml`). When the display name contains spaces (e.g., "Project Documentation"), this produces an invalid namespace name — MediaWiki requires underscores, not spaces, in namespace names.

Changed `$wgMetaNamespace` to use the display name with spaces replaced by underscores via `str_replace( ' ', '_', $wgSitename )`. Admins who want a custom Project namespace can override `$wgMetaNamespace` in a per-wiki settings file.

Closes #78

## Test plan

- [ ] Create a wiki with a multi-word display name (e.g., `-t "Project Documentation"`)
- [ ] Verify `$wgSitename` displays correctly with spaces
- [ ] Verify the Project namespace uses underscores (e.g., `Project_Documentation:Page_title`)
- [ ] Verify overriding `$wgMetaNamespace` in a per-wiki settings file works