### PR TITLE
Fix path-based wikis and auto-update skipped without LocalSettings.php

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -260,7 +260,7 @@ COPY _sources/images/Powered-by-Canasta.png /var/www/mediawiki/w/resources/asset
 EXPOSE 80
 WORKDIR $MW_HOME
 
-HEALTHCHECK --interval=1m --timeout=10s \
+HEALTHCHECK --interval=1m --timeout=10s --start-period=5m \
 	CMD wget -q --method=HEAD localhost/server-status
 
 CMD ["/run-all.sh"]

--- a/_sources/scripts/run-all.sh
+++ b/_sources/scripts/run-all.sh
@@ -96,9 +96,9 @@ if [ -e "$MW_VOLUME/config/wikis.yaml" ]; then
   create_storage_dirs
 fi
 
-echo "Checking for LocalSettings..."
-if [ -e "$MW_VOLUME/config/LocalSettings.php" ] || [ -e "$MW_VOLUME/config/CommonSettings.php" ]; then
-  # Run auto-update
+echo "Checking for configuration..."
+if [ -e "$MW_VOLUME/config/wikis.yaml" ] || [ -e "$MW_VOLUME/config/LocalSettings.php" ] || [ -e "$MW_VOLUME/config/CommonSettings.php" ]; then
+  # Run auto-update (LocalSettings.php/CommonSettings.php checks are for backward compatibility)
   . /run-maintenance-scripts.sh
   run_autoupdate
 fi

--- a/_sources/scripts/run-all.sh
+++ b/_sources/scripts/run-all.sh
@@ -101,9 +101,11 @@ if [ -e "$MW_VOLUME/config/LocalSettings.php" ] || [ -e "$MW_VOLUME/config/Commo
   # Run auto-update
   . /run-maintenance-scripts.sh
   run_autoupdate
-  if [ -e "$MW_VOLUME/config/wikis.yaml" ]; then
-    config_subdir_wikis
-  fi
+fi
+
+# Configure Apache rewrites for path-based wikis (e.g., localhost/wiki2)
+if [ -e "$MW_VOLUME/config/wikis.yaml" ]; then
+  config_subdir_wikis
 fi
 
 echo "Starting services..."

--- a/_sources/scripts/run-all.sh
+++ b/_sources/scripts/run-all.sh
@@ -96,8 +96,8 @@ if [ -e "$MW_VOLUME/config/wikis.yaml" ]; then
   create_storage_dirs
 fi
 
-echo "Checking for configuration..."
-if [ -e "$MW_VOLUME/config/wikis.yaml" ] || [ -e "$MW_VOLUME/config/LocalSettings.php" ] || [ -e "$MW_VOLUME/config/CommonSettings.php" ]; then
+echo "Checking for MediaWiki configuration..."
+if [ -n "$MW_SECRET_KEY" ] || [ -e "$MW_VOLUME/config/LocalSettings.php" ] || [ -e "$MW_VOLUME/config/CommonSettings.php" ]; then
   # Run auto-update (LocalSettings.php/CommonSettings.php checks are for backward compatibility)
   . /run-maintenance-scripts.sh
   run_autoupdate
@@ -127,7 +127,7 @@ else
 fi
 
 echo "Checking permissions of MediaWiki volume dir $MW_VOLUME except $MW_VOLUME/images..."
-make_dir_writable "$MW_VOLUME" -not '(' -path "$MW_VOLUME/images" -prune ')'
+make_dir_writable "$MW_VOLUME" -not '(' -path "$MW_VOLUME/images" -prune ')' &
 
 # Running php-fpm
 /run-php-fpm.sh &


### PR DESCRIPTION
Closes #80

## Summary

- `config_subdir_wikis` was only called when `config/LocalSettings.php` or `config/CommonSettings.php` existed. Current installations use `MW_SECRET_KEY` env var instead, so Apache was never configured to serve path-based wiki URLs like `/two/w/load.php`, causing unstyled pages. Moved the call outside the guard so it runs whenever `wikis.yaml` exists.
- `run_autoupdate` was inside the same guard. Changed to check `MW_SECRET_KEY` env var instead (`LocalSettings.php`/`CommonSettings.php` checks kept for backward compatibility). Note: `wikis.yaml` cannot be used here because it exists before `install.php` runs, which would cause a crash-loop on first startup.
- Added `--start-period=5m` to the Docker healthcheck to prevent the container from being marked unhealthy during initialization.
- Moved `make_dir_writable` to run in the background so it doesn't block Apache from starting (matching how `update-images-permissions.sh` already runs).

## Test plan

- [x] `canasta create -i wikifarm -w main -a admin -n localhost`
- [x] `canasta add -w two -a admin -u localhost/two`
- [x] Visit `localhost/two/wiki/Main_Page` — page should be fully styled
- [x] Verify first wiki at `localhost/wiki/Main_Page` still works
- [x] Verify auto-update runs on container startup (check logs for "Auto-update completed")
- [x] Verify container starts without health check timeout