### PR TITLE
Return clean 404 for unrecognized URLs in FarmConfigLoader

### DIFF
--- a/_sources/canasta/FarmConfigLoader.php
+++ b/_sources/canasta/FarmConfigLoader.php
@@ -143,8 +143,8 @@ if ( $key === null ) {
 	HttpStatus::header( 404 );
 	header( 'Cache-Control: no-cache' );
 	header( 'Content-Type: text/html; charset=utf-8' );
-	echo("URL not found");
-	throw new Exception( "Error: $key does not exist in urlToWikiIdMap." );
+	echo "Not Found";
+	exit;
 }
 
 // Get the configuration for the selected wiki


### PR DESCRIPTION
Closes #82

## Summary

- Replace `throw new Exception(...)` with `exit` when a URL doesn't match any wiki in `urlToWikiIdMap`
- Requests for static assets like `favicon.svg` and `site.webmanifest` now return a clean 404 instead of generating PHP fatal errors and stack traces in the Apache error log

## Test plan

- [ ] Visit a valid wiki URL — should load normally
- [ ] Visit an unrecognized URL (e.g., `example.com/favicon.svg`) — should return 404 without error log entries