### PR TITLE
Replace per-extension composer install with unified autoloader

### DIFF
--- a/_sources/canasta/CanastaDefaultSettings.php
+++ b/_sources/canasta/CanastaDefaultSettings.php
@@ -100,6 +100,9 @@ $wgDBprefix = "";
 $wgDBssl = false;
 $wgDBTableOptions = "ENGINE=InnoDB, DEFAULT CHARSET=binary";
 
+# Semantic MediaWiki: store smw.json on the persistent volume
+$smwgConfigFileDir = getenv( 'MW_VOLUME' ) . '/config/smw';
+
 # Cache (Canasta uses APCu)
 $wgMainCacheType = CACHE_ACCEL;
 $wgMemCachedServers = [];

--- a/_sources/scripts/extensions-skins.php
+++ b/_sources/scripts/extensions-skins.php
@@ -140,13 +140,11 @@ foreach (['extensions' => 'canasta-extensions', 'skins' => 'canasta-skins'] as $
 }
 
 // Create composer.local.json with specific entries for bundled extensions/skins
-// that have composer dependencies, plus wildcards for user-extensions/skins.
-// We use specific entries rather than extensions/*/composer.json wildcards to
-// avoid broken composer.json files in extensions that don't need composer.
-$allIncludes = array_merge($composerIncludes, [
-    'user-extensions/*/composer.json',
-    'user-skins/*/composer.json',
-]);
+// that have composer dependencies. We use specific entries rather than wildcards
+// to avoid broken composer.json files in extensions that don't need composer.
+// Users who add extensions with composer dependencies should manually add
+// entries to config/composer.local.json.
+$allIncludes = $composerIncludes;
 $composerLocal = [
     'extra' => [
         'merge-plugin' => [

--- a/_sources/scripts/extensions-skins.php
+++ b/_sources/scripts/extensions-skins.php
@@ -85,7 +85,6 @@ foreach (['extensions', 'skins'] as $type) {
                     // Skip per-extension composer install; dependencies will be
                     // resolved by the unified root-level composer update below.
                     $composerIncludes[] = "$type/$name/composer.json";
-                    echo "Skipping per-extension composer install for $name (will use unified autoloader)\n";
                 } elseif ($step === "git submodule update") {
                     $submoduleUpdateCmd = "cd $MW_HOME/canasta-$type/$name && git submodule update --init";
                     exec($submoduleUpdateCmd);

--- a/_sources/scripts/extensions-skins.php
+++ b/_sources/scripts/extensions-skins.php
@@ -82,8 +82,7 @@ foreach (['extensions', 'skins'] as $type) {
         if ($additionalSteps !== null) {
             foreach ($additionalSteps as $step) {
                 if ($step === "composer update") {
-                    // Skip per-extension composer install; dependencies will be
-                    // resolved by the unified root-level composer update below.
+                    // Dependencies will be resolved by the unified root-level composer update below.
                     $composerIncludes[] = "$type/$name/composer.json";
                 } elseif ($step === "git submodule update") {
                     $submoduleUpdateCmd = "cd $MW_HOME/canasta-$type/$name && git submodule update --init";

--- a/_sources/scripts/run-all.sh
+++ b/_sources/scripts/run-all.sh
@@ -26,15 +26,15 @@ set -x
 # To opt out of runtime composer updates, delete config/composer.local.json
 # or empty its include array. The build-time autoloader will be used as-is.
 COMPOSER_LOCAL="$MW_VOLUME/config/composer.local.json"
-HAS_GLOBS=false
+HAS_INCLUDES=false
 if [ -f "$COMPOSER_LOCAL" ]; then
-  HAS_GLOBS=$(php -r '
+  HAS_INCLUDES=$(php -r '
     $data = json_decode(file_get_contents("'"$COMPOSER_LOCAL"'"), true);
     $include = $data["extra"]["merge-plugin"]["include"] ?? [];
     echo count($include) > 0 ? "true" : "false";
   ')
 fi
-if [ "$HAS_GLOBS" = "true" ]; then
+if [ "$HAS_INCLUDES" = "true" ]; then
   cp "$COMPOSER_LOCAL" "$MW_HOME/composer.local.json"
   CURRENT_HASH=$(php -r '
     $clj = json_decode(file_get_contents("'"$MW_HOME"'/composer.local.json"), true);
@@ -60,7 +60,7 @@ if [ "$HAS_GLOBS" = "true" ]; then
     echo "Composer dependencies unchanged, skipping update."
   fi
 else
-  echo "No composer.local.json globs found, using build-time autoloader."
+  echo "No composer.local.json includes found, using build-time autoloader."
 fi
 
 # Soft sync contents from $MW_ORIGIN_FILES directory to $MW_VOLUME

--- a/_sources/scripts/run-all.sh
+++ b/_sources/scripts/run-all.sh
@@ -157,6 +157,15 @@ if [ -n "$MW_SECRET_KEY" ] || [ -e "$MW_VOLUME/config/LocalSettings.php" ] || [ 
   # Run auto-update (LocalSettings.php/CommonSettings.php checks are for backward compatibility)
   . /run-maintenance-scripts.sh
   run_autoupdate
+
+  # Initialize Semantic MediaWiki store if SMW is enabled but not yet set up
+  if [ -f "$MW_HOME/extensions/SemanticMediaWiki/extension.json" ]; then
+    mkdir -p "$MW_VOLUME/config/smw"
+    if [ ! -f "$MW_VOLUME/config/smw/smw.json" ]; then
+      echo "Initializing Semantic MediaWiki store..."
+      php "$MW_HOME/extensions/SemanticMediaWiki/maintenance/setupStore.php"
+    fi
+  fi
 fi
 
 # Configure Apache rewrites for path-based wikis (e.g., localhost/wiki2)

--- a/_sources/scripts/run-all.sh
+++ b/_sources/scripts/run-all.sh
@@ -11,11 +11,11 @@ set -x
 #
 # The Canasta image builds a unified vendor/autoload.php at build time using
 # composer.local.json with merge-plugin includes for specific bundled
-# extensions/skins that have composer dependencies, plus wildcards for
-# user-extensions and user-skins. At runtime, we check whether the user's
-# config/composer.local.json differs from what was used at build time and
-# re-run composer update if so. This picks up new user-extensions with
-# composer.json files and any custom edits to composer.local.json.
+# extensions/skins that have composer dependencies. At runtime, we check
+# whether the user's config/composer.local.json differs from what was used
+# at build time and re-run composer update if so. Users who add extensions
+# with composer dependencies should manually add entries to
+# config/composer.local.json.
 #
 # Behavior based on config/composer.local.json state:
 #   - Missing: build-time autoloader is preserved as-is, no runtime update


### PR DESCRIPTION
## Summary
- Skip per-extension `composer install` in `extensions-skins.php`; log a message instead
- After the main extension/skin loop, create build-time symlinks in `extensions/`/`skins/` → `canasta-extensions/`/`canasta-skins/` so composer.json references work at build time
- Write `composer.local.json` with specific entries for bundled extensions that need composer (identified by "composer update" in their additional steps)
- Run a single root-level `composer update` to produce a unified `vendor/autoload.php`
- Save a hash of all contributing `composer.json` files to `.composer-deps-hash`
- Save `composer.local.json` to `$MW_ORIGIN_FILES/config/` so it is synced to the user's `config/` volume via `rsync --ignore-existing` on first container start
- In `run-all.sh`, detect changes to `composer.local.json` at runtime and re-run `composer update` only when needed; users who add extensions with composer dependencies should manually add entries to `config/composer.local.json`
- If `composer.local.json` is missing or has an empty include array, use the build-time autoloader as-is
- Set `$smwgConfigFileDir` in `CanastaDefaultSettings.php` to store `.smw.json` on the persistent volume (`config/smw/`)
- Auto-run `rebuildData.php` for newly-setup SMW wikis: snapshot `.smw.json` wiki IDs before `run_autoupdate` (which triggers `setupStore.php` via hooks), then run `rebuildData.php` for any new entries; supports wiki farms with per-wiki detection

Closes #84

**Merge order:** This PR is **1 of 4** — merge first, then CanastaWiki/Canasta#578, then CanastaWiki/Canasta-DockerCompose#91, then CanastaWiki/Canasta-CLI#236.

## Test plan
- [x] Build CanastaBase image, then Canasta image on top, and verify no per-extension `vendor/` directories exist under `canasta-extensions/` (e.g. `canasta-extensions/CirrusSearch/vendor/` should not exist)
- [x] Verify `composer.local.json` exists in the built image with specific extension entries (no wildcards)
- [x] Verify `.composer-deps-hash` exists in the built image
- [x] Verify SMW classes are in the unified autoloader: `php -r "require '/var/www/mediawiki/w/vendor/autoload.php'; echo class_exists('SMW\Setup') ? 'OK' : 'FAIL';"`
- [x] Fresh `canasta create`: verify `config/composer.local.json` is synced from the image on first container start
- [x] Enable SMW via `wfLoadExtension('SemanticMediaWiki'); enableSemantics('localhost');` and verify `setupStore.php` runs automatically via `update.php` hooks and `rebuildData.php` runs afterward
- [x] Verify `config/smw/.smw.json` is created on the persistent volume with a key for the wiki ID
- [x] Wiki farm: add a new wiki and verify `rebuildData.php` runs only for the new wiki
- [x] Test runtime: manually add a user-extension entry to `config/composer.local.json`, restart container, verify `composer update` runs
- [x] Test runtime: restart without changes, verify `composer update` is skipped
- [x] Test runtime: delete `config/composer.local.json`, restart, verify build-time autoloader is used as-is
