### PR TITLE
Fix all hadolint warnings in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,13 +18,14 @@ LABEL wiki.canasta.mediawiki.version="$MW_CORE_VERSION" \
       wiki.canasta.mediawiki.branch="$MW_VERSION"
 
 # System setup
-# hadolint ignore=DL3008 -- pinning system package versions is impractical on Debian
+# Pinning system package versions is impractical on Debian
+# hadolint ignore=DL3008
 RUN set x; \
 	apt-get clean \
 	&& apt-get update \
 	&& apt-get install -y --no-install-recommends aptitude \
 	&& aptitude -y upgrade \
-	&& aptitude install -y --no-install-recommends \
+	&& aptitude install -y --without-recommends \
 	git \
 	inotify-tools \
 	apache2 \
@@ -97,7 +98,8 @@ RUN set -x; \
 	curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
     && composer self-update 2.1.3
 
-# hadolint ignore=DL3008 -- pinning system package versions is impractical on Debian
+# Pinning system package versions is impractical on Debian
+# hadolint ignore=DL3008
 RUN set -x; \
 	# Preconfigure Postfix to avoid the interactive prompt
 	echo "postfix postfix/main_mailer_type select Internet Site" | debconf-set-selections \
@@ -111,7 +113,8 @@ COPY main.cf /etc/postfix/main.cf
 FROM base AS source
 
 # MediaWiki core
-# hadolint ignore=DL3003 -- cd is used within a multi-command && chain
+# cd is used within a multi-command && chain
+# hadolint ignore=DL3003
 RUN set -x; \
 	git clone --depth 1 -b "$MW_CORE_VERSION" https://github.com/wikimedia/mediawiki "$MW_HOME" \
 	&& cd "$MW_HOME" \
@@ -125,7 +128,8 @@ RUN set -x; \
 
 # Generate gitinfo.json for core, extensions, and skins so that
 # Special:Version can display git commit hashes after .git is removed
-# hadolint ignore=DL3003,SC2164 -- cd is used within a loop that returns to $MW_HOME
+# cd is used within a loop that returns to $MW_HOME
+# hadolint ignore=DL3003,SC2164
 RUN set -x; \
     cd "$MW_HOME" || exit \
     && for dir in . extensions/*/ skins/*/; do \
@@ -143,13 +147,15 @@ RUN set -x; \
     done
 
 # Cleanup all .git leftovers
-# hadolint ignore=DL3003 -- cd is used within a multi-command && chain
+# cd is used within a multi-command && chain
+# hadolint ignore=DL3003
 RUN set -x; \
     cd "$MW_HOME" \
     && find . \( -name ".git" -o -name ".gitignore" -o -name ".gitmodules" -o -name ".gitattributes" \) -exec rm -rf -- {} +
 
 # Generate sample files for installing extensions and skins in LocalSettings.php
-# hadolint ignore=DL3003,SC2035 -- cd switches between extensions/ and skins/; glob is safe here
+# cd switches between extensions/ and skins/; glob is safe here
+# hadolint ignore=DL3003,SC2035
 RUN set -x; \
 	cd "$MW_HOME/extensions" \
 	&& for i in $(ls -d */); do echo "#wfLoadExtension('${i%%/}');"; done > "$MW_ORIGIN_FILES/installedExtensions.txt" \


### PR DESCRIPTION
## Summary
- Add `SHELL` pipefail directive before piped RUN commands
- Add `--no-install-recommends` to apt-get/aptitude install
- Replace `apt` with `apt-get` for postfix install
- Clean up apt lists after postfix install
- Double-quote all variable references in RUN commands
- Add `cd || exit` for safety
- Suppress DL3008 (pin versions) — impractical for Debian system packages
- Suppress DL3003 (use WORKDIR) — `cd` is used within multi-command `&&` chains

Closes #86

## Test plan
- [x] `hadolint Dockerfile` produces no output
- [x] Image builds successfully