### PR TITLE
Fix log directory permissions in run-all.sh non-mountpoint branch

### DIFF
--- a/_sources/scripts/run-all.sh
+++ b/_sources/scripts/run-all.sh
@@ -216,7 +216,8 @@ if ! mountpoint -q -- "$MW_LOG"; then
     rsync -avh --ignore-existing "$MW_LOG/" "$MW_VOLUME/log/mediawiki/"
     mv "$MW_LOG" "${MW_LOG}_old"
     ln -s "$MW_VOLUME/log/mediawiki" "$MW_LOG"
-    chmod -R o=rwX "$MW_VOLUME/log/mediawiki"
+    chgrp -R "$WWW_GROUP" "$MW_VOLUME/log/mediawiki"
+    chmod -R g=rwX "$MW_VOLUME/log/mediawiki"
 else
     chgrp -R "$WWW_GROUP" "$MW_LOG"
     chmod -R go=rwX "$MW_LOG"


### PR DESCRIPTION
## Summary

- Adds missing `chgrp -R "$WWW_GROUP"` to the non-mountpoint branch for the MediaWiki log directory
- Changes `chmod -R o=rwX` (other only) to `chmod -R g=rwX` (group), matching the pattern used by every other log permission block in the file

## Problem

When `/var/log/mediawiki` is not a bind mount, the directory is created as `root:root` with no group write permission. The `www-data` user then gets "Permission denied" when writing log files (e.g., `mwjobrunner_log_*`).

The bug was latent since #420 but masked by the synchronous `make_dir_writable` call that followed. It became visible after #81 backgrounded that call.

Fixes #89

## Test plan

- Build CanastaBase image without a log bind mount for `/var/log/mediawiki`
- Start the container and verify `/var/log/mediawiki` has group `www-data` and group write permission
- Confirm job runner log files are created without "Permission denied" errors