### PR TITLE
Remove installedExtensions.txt and installedSkins.txt generation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -153,17 +153,6 @@ RUN set -x; \
     cd "$MW_HOME" \
     && find . \( -name ".git" -o -name ".gitignore" -o -name ".gitmodules" -o -name ".gitattributes" \) -exec rm -rf -- {} +
 
-# Generate sample files for installing extensions and skins in LocalSettings.php
-# cd switches between extensions/ and skins/; glob is safe here
-# hadolint ignore=DL3003,SC2035
-RUN set -x; \
-	cd "$MW_HOME/extensions" \
-	&& for i in $(ls -d */); do echo "#wfLoadExtension('${i%%/}');"; done > "$MW_ORIGIN_FILES/installedExtensions.txt" \
-    && cd "$MW_HOME/skins" \
-	&& for i in $(ls -d */); do echo "#wfLoadSkin('${i%%/}');"; done > "$MW_ORIGIN_FILES/installedSkins.txt" \
-    # Load Vector skin by default in the sample file
-    && sed -i "s/#wfLoadSkin('Vector');/wfLoadSkin('Vector');/" "$MW_ORIGIN_FILES/installedSkins.txt"
-
 # Move files around
 RUN set -x; \
 	# Move files to $MW_ORIGIN_FILES directory


### PR DESCRIPTION
## Summary

Removes the Dockerfile block that generated `installedExtensions.txt` and `installedSkins.txt`.

## Why

As discussed in #88:
- The files only listed MediaWiki core bundled extensions (~33), not the ~130 extensions added by the Canasta layer
- They were rsynced to `$MW_VOLUME/` but not into a bind-mounted subdirectory, so they were not accessible on the host without `docker exec`
- The CLI's `canasta extension enable/disable` commands provide a better workflow for managing extensions
- No one has been using these files

Fixes #88

## Test plan

- Build CanastaBase image and verify it builds successfully
- Verify `installedExtensions.txt` and `installedSkins.txt` no longer exist in the image