### PR TITLE
Allow post-installation processing for composer-installed extensions

### DIFF
--- a/_sources/scripts/extensions-skins.php
+++ b/_sources/scripts/extensions-skins.php
@@ -50,11 +50,9 @@ foreach (['extensions', 'skins'] as $type) {
             $packageVersion = $data['composer-version'] ?? null;
             $packageString = $packageVersion ? "$packageName:$packageVersion" : $packageName;
             exec("composer require $packageString --working-dir=$MW_HOME --no-interaction");
-            continue;
         }
 
-
-        if (!$bundled) {
+        if (!$bundled && !($data['composer-name'] ?? null)) {
             $gitCloneCmd = "git clone ";
 
             if ($repository === null) {


### PR DESCRIPTION
## Summary

- Removes `continue` after `composer require` so composer-installed extensions receive post-installation processing
- Adds `composer-name` check to the git clone condition to skip cloning for composer-installed extensions

## Problem

Extensions configured with `composer-name` in YAML were installed via `composer require` but then immediately hit a `continue` statement, skipping all post-installation steps: patches, additional steps (like `composer update` for dependency merging), persistent directories, gitinfo.json generation, and `.git` cleanup.

No extensions in the current Recommended Revisions YAML use `composer-name`, but this affects users who extend the YAML with their own composer-installed extensions.

## Change

```php
// Before: continue skipped everything after composer require
if ($data['composer-name'] ?? null) {
    exec("composer require ...");
    continue;  // <-- all post-processing skipped
}
if (!$bundled) {
    // git clone
}

// After: composer-name extensions skip git clone but get post-processing
if ($data['composer-name'] ?? null) {
    exec("composer require ...");
}
if (!$bundled && !($data['composer-name'] ?? null)) {
    // git clone
}
```

Fixes #36

## Test plan

- Build CanastaBase and Canasta images successfully
- Add a test extension with `composer-name` and `additional steps: [composer update]` to a custom contents.yaml
- Verify the extension is installed via composer and its composer.json is included in the merge-plugin configuration