### PR TITLE
Move state files to config/persistent/

### DIFF
--- a/_sources/canasta/CanastaDefaultSettings.php
+++ b/_sources/canasta/CanastaDefaultSettings.php
@@ -99,7 +99,7 @@ $wgDBssl = false;
 $wgDBTableOptions = "ENGINE=InnoDB, DEFAULT CHARSET=binary";
 
 # Semantic MediaWiki: store smw.json on the persistent volume
-$smwgConfigFileDir = getenv( 'MW_VOLUME' ) . '/config/smw';
+$smwgConfigFileDir = getenv( 'MW_VOLUME' ) . '/config/persistent';
 
 # Cache (Canasta uses APCu)
 $wgMainCacheType = CACHE_ACCEL;

--- a/_sources/scripts/extensions-skins.php
+++ b/_sources/scripts/extensions-skins.php
@@ -177,7 +177,8 @@ $combinedHash = '';
 foreach ($hashFiles as $f) {
     $combinedHash .= md5_file($f);
 }
-file_put_contents("$MW_HOME/.composer-deps-hash", md5($combinedHash) . "\n");
+exec("mkdir -p $MW_ORIGIN_FILES/config/persistent");
+file_put_contents("$MW_ORIGIN_FILES/config/persistent/.composer-deps-hash", md5($combinedHash) . "\n");
 
 /**
  * Recursive function to allow for loading a whole chain of YAML files (if


### PR DESCRIPTION
## Summary
- Move `.composer-deps-hash` from `$MW_HOME` (non-persistent) to `$MW_VOLUME/config/persistent/` so it survives container restarts, avoiding unnecessary `composer update` on every restart
- Move `.smw.json` from `config/smw/` to `config/persistent/`, grouping internal state files that don't need to be backed up
- Move the runtime composer dependency check to after the rsync so that `composer.local.json` is available when the check runs (needed for Kubernetes where config files aren't pre-populated on the volume)

## Files changed
- `_sources/scripts/extensions-skins.php` — write build-time hash to `$MW_ORIGIN_FILES/config/persistent/`
- `_sources/scripts/run-all.sh` — read/write hash and `.smw.json` from `config/persistent/`; move composer check after rsync
- `_sources/canasta/CanastaDefaultSettings.php` — point `$smwgConfigFileDir` to `config/persistent`

## Test plan
- [x] Build from source with `canasta create --build-from`
- [x] Kubernetes: first boot shows "Composer dependencies unchanged, skipping update"
- [x] Kubernetes: restart preserves hash, skips composer update
- [x] Docker Compose: first boot shows "Composer dependencies unchanged, skipping update"
- [x] Docker Compose: enable SMW, restart — `.smw.json` created in `config/persistent/`
- [x] Docker Compose: second restart — SMW detected as already set up (`.smw.json` persisted)

Fixes #102
Companion PR: CanastaWiki/Canasta-CLI#346 (adds K8s volume mount)