### PR TITLE
Run maintenance scripts in lexicographical order

### DIFF
--- a/_sources/scripts/run-maintenance-scripts.sh
+++ b/_sources/scripts/run-maintenance-scripts.sh
@@ -147,7 +147,7 @@ run_autoupdate () {
 
 run_maintenance_scripts() {
   # Iterate through all the .sh files in /maintenance-scripts/ directory
-  for maintenance_script in $(find /maintenance-scripts/ -maxdepth 1 -mindepth 1 -type f -name "*.sh"); do
+  for maintenance_script in $(find /maintenance-scripts/ -maxdepth 1 -mindepth 1 -type f -name "*.sh" | sort); do
     script_name=$(basename "$maintenance_script")
 
     # If the script's name starts with "mw_", run it with the run_mw_script function


### PR DESCRIPTION
## Summary

- Add `| sort` to the `find` command in `run_maintenance_scripts()` so scripts in `/maintenance-scripts/` run in lexicographical order instead of arbitrary filesystem order

This lets users control execution order by naming scripts with numeric prefixes (e.g., `01_first.sh`, `02_second.sh`).

Fixes CanastaWiki/Canasta#381