### PR TITLE
Derive $wgServer scheme from MW_SITE_SERVER instead of hardcoding HTTPS

### DIFF
--- a/_sources/canasta/FarmConfigLoader.php
+++ b/_sources/canasta/FarmConfigLoader.php
@@ -164,7 +164,8 @@ if ( !empty( $selectedWikiConfig ) ) {
 }
 
 // Configure the wiki server and URL paths
-$wgServer = "https://$serverName";
+$scheme = parse_url( getenv( 'MW_SITE_SERVER' ) ?: 'https://localhost', PHP_URL_SCHEME ) ?: 'https';
+$wgServer = "$scheme://$serverName";
 $wgScriptPath = !empty( $path )
 	? "/$path/w"
 	: "/w";


### PR DESCRIPTION
## Summary

- Fixes the hardcoded `https://` scheme in `FarmConfigLoader.php` that causes redirect loops when `CADDY_AUTO_HTTPS=off`
- Extracts the scheme from `MW_SITE_SERVER` using `parse_url()`, defaulting to `https` when unset
- Follows the same pattern already used in `robots.php:21`

Fixes #109

## Test plan

- [x] Build test image from local CanastaBase: `canasta create --build-from <path>`
- [x] With `MW_SITE_SERVER=https://...` (default): confirm `$wgServer` is `https://`
- [x] After `canasta config set MW_SITE_SERVER=http://...` + `CADDY_AUTO_HTTPS=off`: confirm `$wgServer` is `http://` and the site loads without redirect loops