### PR TITLE
Add styled 404 page and optional wiki directory for wiki farms

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -226,7 +226,7 @@ COPY _sources/scripts/extensions-skins.php /tmp/
 COPY _sources/configs/robots-main.txt _sources/configs/robots.php $WWW_ROOT/
 COPY _sources/configs/.htaccess $WWW_ROOT/
 COPY _sources/images/favicon.ico $WWW_ROOT/
-COPY _sources/canasta/LocalSettings.php _sources/canasta/CanastaDefaultSettings.php _sources/canasta/FarmConfigLoader.php $MW_HOME/
+COPY _sources/canasta/LocalSettings.php _sources/canasta/CanastaDefaultSettings.php _sources/canasta/FarmConfigLoader.php _sources/canasta/CanastaFarm404.php $MW_HOME/
 COPY _sources/canasta/getMediawikiSettings.php /
 COPY _sources/canasta/canasta_img.php _sources/canasta/public_assets.php $MW_HOME/
 COPY _sources/configs/mpm_event.conf /etc/apache2/mods-available/mpm_event.conf

--- a/_sources/canasta/CanastaFarm404.php
+++ b/_sources/canasta/CanastaFarm404.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * CanastaFarm404.php — styled 404 page and wiki directory for Canasta wiki farms.
+ *
+ * Loaded by FarmConfigLoader.php in two modes:
+ *   - 404 mode ($directoryOnly = false): shows error box + optional wiki directory
+ *   - Directory mode ($directoryOnly = true): shows wiki directory as a landing page
+ *
+ * Variables in scope from the caller: $wikiConfigurations, $urlComponents, $path,
+ * $directoryOnly.
+ *
+ * In 404 mode, the directory is shown only when CANASTA_ENABLE_WIKI_DIRECTORY is "true".
+ * In directory mode, the directory is always shown (the caller already checked the env var).
+ */
+
+$directoryOnly = !empty( $directoryOnly );
+$showDirectory = $directoryOnly || ( getenv( 'CANASTA_ENABLE_WIKI_DIRECTORY' ) === 'true' );
+$scheme = parse_url( getenv( 'MW_SITE_SERVER' ) ?: 'https://localhost', PHP_URL_SCHEME ) ?: 'https';
+$requestedPath = isset( $urlComponents['path'] ) ? htmlspecialchars( $urlComponents['path'], ENT_QUOTES, 'UTF-8' ) : '/';
+$pageTitle = $directoryOnly ? 'Wiki Directory' : 'Page Not Found';
+
+?><!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title><?php echo $pageTitle; ?></title>
+<style>
+*,*::before,*::after{box-sizing:border-box}
+body{margin:0;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;background:#f5f5f5;color:#333}
+.container{max-width:960px;margin:0 auto;padding:40px 20px}
+.error-box{background:#fff;border:1px solid #ddd;border-radius:8px;padding:40px;text-align:center;margin-bottom:40px}
+.error-box h1{font-size:48px;margin:0 0 8px;color:#c00}
+.error-box p{font-size:18px;margin:0;color:#555}
+.error-box code{background:#f0f0f0;padding:2px 8px;border-radius:4px;font-size:16px}
+.directory h2{font-size:22px;margin:0 0 20px;color:#333}
+.wiki-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(220px,1fr));gap:16px}
+.wiki-card{background:#fff;border:1px solid #ddd;border-radius:8px;overflow:hidden;transition:box-shadow .15s}
+.wiki-card:hover{box-shadow:0 2px 8px rgba(0,0,0,.12)}
+.wiki-card a{display:block;text-decoration:none;color:inherit;padding:20px;text-align:center}
+.wiki-card .logo{width:80px;height:80px;margin:0 auto 12px;display:flex;align-items:center;justify-content:center}
+.wiki-card .logo img{max-width:80px;max-height:80px;display:none}
+.wiki-card .name{font-size:16px;font-weight:600;color:#0645ad}
+</style>
+</head>
+<body>
+<div class="container">
+<?php if ( !$directoryOnly ): ?>
+  <div class="error-box">
+    <h1>404</h1>
+    <p>Page not found: <code><?php echo $requestedPath; ?></code></p>
+  </div>
+<?php endif; ?>
+<?php if ( $showDirectory && isset( $wikiConfigurations['wikis'] ) && is_array( $wikiConfigurations['wikis'] ) ): ?>
+  <div class="directory">
+    <h2>Available wikis</h2>
+    <div class="wiki-grid">
+<?php foreach ( $wikiConfigurations['wikis'] as $wiki ):
+	$wikiName = htmlspecialchars( $wiki['name'] ?? $wiki['id'] ?? 'Wiki', ENT_QUOTES, 'UTF-8' );
+	$wikiUrl = $scheme . '://' . htmlspecialchars( $wiki['url'] ?? '', ENT_QUOTES, 'UTF-8' );
+	$wikiId = htmlspecialchars( $wiki['id'] ?? '', ENT_QUOTES, 'UTF-8' );
+?>
+      <div class="wiki-card">
+        <a href="<?php echo $wikiUrl; ?>">
+          <div class="logo"><img alt="" data-wiki-id="<?php echo $wikiId; ?>" data-api="<?php echo $wikiUrl; ?>/w/api.php"></div>
+          <div class="name"><?php echo $wikiName; ?></div>
+        </a>
+      </div>
+<?php endforeach; ?>
+    </div>
+  </div>
+<script>
+document.querySelectorAll('.wiki-card img[data-api]').forEach(function(img) {
+  var url = img.getAttribute('data-api') +
+    '?action=query&meta=siteinfo&siprop=general&format=json&origin=*';
+  fetch(url).then(function(r) {
+    if (!r.ok) throw 0;
+    return r.json();
+  }).then(function(d) {
+    var logo = d && d.query && d.query.general && d.query.general.logo;
+    if (!logo) return;
+    var test = new Image();
+    test.onload = function() {
+      img.src = logo;
+      img.style.display = 'block';
+    };
+    test.src = logo;
+  }).catch(function() {});
+});
+</script>
+<?php endif; ?>
+</div>
+</body>
+</html>

--- a/_sources/canasta/FarmConfigLoader.php
+++ b/_sources/canasta/FarmConfigLoader.php
@@ -134,6 +134,17 @@ if ( $cliDefaultToFirstWiki && $wikiID === null ) {
 	}
 }
 
+// Check if the path is the wiki directory route
+if ( $path === 'wikis' && $wikiID === null ) {
+	if ( getenv( 'CANASTA_ENABLE_WIKI_DIRECTORY' ) === 'true' ) {
+		header( 'Cache-Control: no-cache' );
+		header( 'Content-Type: text/html; charset=utf-8' );
+		$directoryOnly = true;
+		require __DIR__ . '/CanastaFarm404.php';
+		exit;
+	}
+}
+
 // Check if the key is null or if it exists in the urlToWikiIdMap, else throw an exception
 if ( $key === null ) {
 	throw new Exception( "Error: Key is null." );
@@ -143,7 +154,8 @@ if ( $key === null ) {
 	HttpStatus::header( 404 );
 	header( 'Cache-Control: no-cache' );
 	header( 'Content-Type: text/html; charset=utf-8' );
-	echo "Not Found";
+	$directoryOnly = false;
+	require __DIR__ . '/CanastaFarm404.php';
 	exit;
 }
 


### PR DESCRIPTION
## Summary

- Replace bare "Not Found" text on unrecognized wiki farm paths with a styled HTML 404 page
- Add optional wiki directory showing a card grid of all wikis with links and async-loaded logos via the siteinfo API
- Directory controlled by `CANASTA_ENABLE_WIKI_DIRECTORY` env var (disabled by default)
- When enabled, directory also available as a landing page at `/wikis`
- Logo loading failures (private wikis, network errors) are silently ignored

Companion PR: https://github.com/CanastaWiki/Canasta-CLI/pull/388

Closes #112

## Test plan

- [x] Browse to an unrecognized path on a wiki farm — should see styled 404, no directory
- [x] Set `CANASTA_ENABLE_WIKI_DIRECTORY=true` and restart — 404 page shows wiki directory with cards
- [x] Browse to `/wikis` with directory enabled — standalone directory landing page (200 status)
- [x] Browse to `/wikis` with directory disabled — falls through to 404
- [x] Test with a private wiki in the farm — card appears, no logo, no errors