### PR TITLE
Load YAML settings files for extensions/skins

### DIFF
--- a/_sources/canasta/CanastaDefaultSettings.php
+++ b/_sources/canasta/CanastaDefaultSettings.php
@@ -143,7 +143,7 @@ function isEnvTrue( $name ): bool {
  * files (see Manual:YAML_settings_file_format).
  *
  * Files are loaded in lexicographic order. The Canasta CLI manages a file called
- * CanastaManaged.yaml; users may add their own YAML files alongside it.
+ * settings.yaml; users may add their own YAML files alongside it.
  *
  * This runs during the SettingsBuilder "loading" stage (within LocalSettings.php
  * processing), so loadFile() is available. Extensions and skins are queued and
@@ -197,7 +197,7 @@ if ( !is_dir( $globalSettingsDir ) ) {
 	$globalSettingsDir = getenv( 'MW_VOLUME' ) . '/config/settings';
 }
 
-// Load extensions/skins from YAML files (e.g. CanastaManaged.yaml) before
+// Load extensions/skins from YAML files (e.g. settings.yaml) before
 // user PHP files so that user settings can configure loaded extensions.
 canastaLoadConfigYaml( $globalSettingsDir );
 

--- a/_sources/canasta/FarmConfigLoader.php
+++ b/_sources/canasta/FarmConfigLoader.php
@@ -195,6 +195,10 @@ if ( !is_dir( $wikiConfigDir ) ) {
 	$wikiConfigDir = getenv( 'MW_VOLUME' ) . "/config/{$wikiID}";
 }
 
+// Load extensions/skins from per-wiki YAML files (e.g. CanastaManaged.yaml)
+// before user PHP files so that user settings can configure loaded extensions.
+canastaLoadConfigYaml( $wikiConfigDir );
+
 $files = glob( $wikiConfigDir . '/*.php' );
 
 // Check if the glob function was successful, else continue with the execution

--- a/_sources/canasta/FarmConfigLoader.php
+++ b/_sources/canasta/FarmConfigLoader.php
@@ -195,7 +195,7 @@ if ( !is_dir( $wikiConfigDir ) ) {
 	$wikiConfigDir = getenv( 'MW_VOLUME' ) . "/config/{$wikiID}";
 }
 
-// Load extensions/skins from per-wiki YAML files (e.g. CanastaManaged.yaml)
+// Load extensions/skins from per-wiki YAML files (e.g. settings.yaml)
 // before user PHP files so that user settings can configure loaded extensions.
 canastaLoadConfigYaml( $wikiConfigDir );
 


### PR DESCRIPTION
## Summary

- Add `canastaLoadConfigYaml()` helper that uses `$wgSettings->loadFile()` to load all `*.yaml` files in a settings directory in lexicographic order
- Call it in `CanastaDefaultSettings.php` (global settings) and `FarmConfigLoader.php` (per-wiki settings) before the `*.php` glob loop so user PHP files can configure loaded extensions
- No-op if no YAML files exist, so safe to deploy before the companion CLI changes

The Canasta CLI manages a file called `main.yaml`; users may also add their own YAML files alongside it.

Companion to CanastaWiki/Canasta-CLI#463.

## Test plan

- [x] Verify existing installations without YAML files are unaffected
- [x] Create a `config/settings/global/main.yaml` with extensions/skins and verify they load
- [x] Create a per-wiki `config/settings/wikis/{wiki}/main.yaml` and verify wiki-specific loading
- [x] Verify user PHP files in the same directory still work and can configure loaded extensions

Fixes #116