### PR TITLE
Switch FarmConfigLoader from PECL yaml to Symfony YAML parser

### DIFF
--- a/_sources/canasta/FarmConfigLoader.php
+++ b/_sources/canasta/FarmConfigLoader.php
@@ -5,6 +5,8 @@ if ( !defined( 'MEDIAWIKI' ) ) {
 	exit;
 }
 
+use Symfony\Component\Yaml\Yaml;
+
 // Get the original URL from the environment variables
 $original_url = getenv( 'ORIGINAL_URL' );
 $serverName = "";
@@ -76,12 +78,7 @@ try {
 	}
 
 	// Parse the configuration file
-	$wikiConfigurations = yaml_parse_file( $file );
-
-	// Check if file parsing was successful, else throw an exception
-	if ( $wikiConfigurations === false ) {
-		throw new Exception( 'Error parsing the configuration file' );
-	}
+	$wikiConfigurations = Yaml::parseFile( $file );
 } catch ( Exception $e ) {
 	die( 'Caught exception: ' . $e->getMessage() );
 }


### PR DESCRIPTION
## Summary

- Replaces `yaml_parse_file()` with Symfony's `Yaml::parseFile()` in `FarmConfigLoader.php`
- FarmConfigLoader runs during MediaWiki bootstrap after the Composer autoloader is loaded, so Symfony's YAML component is available
- The existing `catch (Exception $e)` block handles Symfony's `ParseException` (which extends `RuntimeException` → `Exception`)
- `public_assets.php` remains on the PECL extension since it's a standalone entry point without the autoloader

## Test plan

- [x] Create a wiki farm instance with multiple wikis configured in `wikis.yaml`
- [x] Verify all wikis load correctly (FarmConfigLoader parses the YAML)
- [x] Verify CLI mode defaults to first wiki (`php maintenance/run.php showSiteStats`)

Refs #117