### PR TITLE
Skip Varnish CDN settings when CANASTA_ENABLE_VARNISH is not set

### DIFF
--- a/_sources/canasta/CanastaDefaultSettings.php
+++ b/_sources/canasta/CanastaDefaultSettings.php
@@ -105,18 +105,20 @@ $smwgConfigFileDir = getenv( 'MW_VOLUME' ) . '/config/persistent';
 $wgMainCacheType = CACHE_ACCEL;
 $wgMemCachedServers = [];
 
-# Docker specific setup
-# Exclude all private IP ranges
-# see https://www.mediawiki.org/wiki/Manual:$wgCdnServersNoPurge
-$wgUseCdn = true;
-$wgCdnServersNoPurge = [];
-$wgCdnServersNoPurge[] = '10.0.0.0/8';     // 10.0.0.0 – 10.255.255.255
-$wgCdnServersNoPurge[] = '172.16.0.0/12';  // 172.16.0.0 – 172.31.255.255
-$wgCdnServersNoPurge[] = '192.168.0.0/16'; // 192.168.0.0 – 192.168.255.255
+# Varnish cache configuration (only when enabled via CANASTA_ENABLE_VARNISH)
+if ( isEnvTrue( 'CANASTA_ENABLE_VARNISH' ) ) {
+	# Exclude all private IP ranges from CDN purge restrictions
+	# see https://www.mediawiki.org/wiki/Manual:$wgCdnServersNoPurge
+	$wgUseCdn = true;
+	$wgCdnServersNoPurge = [];
+	$wgCdnServersNoPurge[] = '10.0.0.0/8';     // 10.0.0.0 – 10.255.255.255
+	$wgCdnServersNoPurge[] = '172.16.0.0/12';  // 172.16.0.0 – 172.31.255.255
+	$wgCdnServersNoPurge[] = '192.168.0.0/16'; // 192.168.0.0 – 192.168.255.255
 
-# Configure Varnish cache purging
-$wgCdnServers = [ 'varnish:80' ];
-$wgInternalServer = preg_replace( '/^https:/', 'http:', $wgServer );
+	# Configure Varnish cache purging
+	$wgCdnServers = [ 'varnish:80' ];
+	$wgInternalServer = preg_replace( '/^https:/', 'http:', $wgServer );
+}
 
 /**
  * Returns boolean value from environment variable

--- a/_sources/canasta/CanastaDefaultSettings.php
+++ b/_sources/canasta/CanastaDefaultSettings.php
@@ -105,8 +105,10 @@ $smwgConfigFileDir = getenv( 'MW_VOLUME' ) . '/config/persistent';
 $wgMainCacheType = CACHE_ACCEL;
 $wgMemCachedServers = [];
 
-# Varnish cache configuration (only when enabled via CANASTA_ENABLE_VARNISH)
-if ( isEnvTrue( 'CANASTA_ENABLE_VARNISH' ) ) {
+# Varnish cache configuration (enabled by default for backward compatibility;
+# set CANASTA_ENABLE_VARNISH=false to disable)
+$canastaEnableVarnish = getenv( 'CANASTA_ENABLE_VARNISH' );
+if ( $canastaEnableVarnish === false || $canastaEnableVarnish === '' || isEnvTrue( 'CANASTA_ENABLE_VARNISH' ) ) {
 	# Exclude all private IP ranges from CDN purge restrictions
 	# see https://www.mediawiki.org/wiki/Manual:$wgCdnServersNoPurge
 	$wgUseCdn = true;

--- a/_sources/canasta/CanastaDefaultSettings.php
+++ b/_sources/canasta/CanastaDefaultSettings.php
@@ -107,8 +107,8 @@ $wgMemCachedServers = [];
 
 # Varnish cache configuration (enabled by default for backward compatibility;
 # set CANASTA_ENABLE_VARNISH=false to disable)
-$canastaEnableVarnish = getenv( 'CANASTA_ENABLE_VARNISH' );
-if ( $canastaEnableVarnish === false || $canastaEnableVarnish === '' || isEnvTrue( 'CANASTA_ENABLE_VARNISH' ) ) {
+$canastaEnableVarnish = strtolower( (string)getenv( 'CANASTA_ENABLE_VARNISH' ) );
+if ( $canastaEnableVarnish !== 'false' && $canastaEnableVarnish !== '0' ) {
 	# Exclude all private IP ranges from CDN purge restrictions
 	# see https://www.mediawiki.org/wiki/Manual:$wgCdnServersNoPurge
 	$wgUseCdn = true;


### PR DESCRIPTION
## Summary

- Wraps `$wgUseCdn`, `$wgCdnServers`, `$wgCdnServersNoPurge`, and `$wgInternalServer` in a conditional block
- Varnish CDN settings are enabled by default (env var absent or `true`) for backward compatibility
- Only disabled when `CANASTA_ENABLE_VARNISH` is explicitly set to a non-true value (e.g. `false`)

Fixes #135
Companion PR: CanastaWiki/Canasta-CLI#669

## Test plan

- [x] With `CANASTA_ENABLE_VARNISH=true`: verify `$wgUseCdn` is `true` and `$wgCdnServers` is set
- [x] With `CANASTA_ENABLE_VARNISH=false`: verify `$wgUseCdn` remains default (`false`) and no purge requests are sent
- [x] Without `CANASTA_ENABLE_VARNISH` set at all: CDN settings are enabled (backward compatible)