### PR TITLE
Update GitHub Actions to fix Node.js deprecation warnings

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -111,8 +111,6 @@ jobs:
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-        with:
-          install: true
       -
         name: Login to GitHub Container Registry
         uses: docker/login-action@v3

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' || github.event_name == 'pull_request'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       -
         name: Run linter (hadolint)
         uses: vedmaka/hadolint-action@master
@@ -45,7 +45,7 @@ jobs:
     if: github.event_name == 'push' || github.event_name == 'pull_request'
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       -
         name: Generate tags
         id: generate
@@ -107,15 +107,15 @@ jobs:
           echo "SHA_SHORT=$SHA_SHORT" >> $GITHUB_OUTPUT
       -
         name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v3
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
         with:
           install: true
       -
         name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -123,7 +123,7 @@ jobs:
       -
         name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           platforms: linux/amd64, linux/arm64
@@ -141,12 +141,7 @@ jobs:
       -
         name: Notify about image tag
         if: github.event_name == 'pull_request' && steps.docker_build.outputs.digest != ''
-        uses: hasura/comment-progress@v2.2.0
+        uses: marocchino/sticky-pull-request-comment@v2
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          repository: ${{ github.repository }}
-          number: ${{ github.event.number }}
-          id: comment
+          header: canasta-image-tag
           message: ":whale: The image based on [${{ steps.generate.outputs.SHA_SHORT }}](https://github.com/CanastaWiki/CanastaBase/pull/${{ steps.generate.outputs.REGISTRY_TAGS_PR_NUMBER }}/commits/${{ github.event.pull_request.head.sha }}) commit has been built with `${{ steps.generate.outputs.REGISTRY_TAGS_VERSION }}` tag as [${{ steps.generate.outputs.REGISTRY_TAGS }}](https://github.com/${{ github.repository }}/pkgs/container/${{ env.IMAGE_NAME }}/${{ steps.docker_build.outputs.imageid }}?tag=${{ steps.generate.outputs.REGISTRY_TAGS_VERSION }})"
-          recreate: true
-          fail: false


### PR DESCRIPTION
## Summary
- Update `actions/checkout` v3 → v4
- Update `docker/setup-qemu-action` v1 → v3
- Update `docker/setup-buildx-action` v2 → v3
- Update `docker/login-action` v2 → v3
- Update `docker/build-push-action` v5 → v6
- Replace `hasura/comment-progress` v2.2.0 (Node.js 12, uses deprecated `set-output`) with `marocchino/sticky-pull-request-comment` v2 (Node.js 24)

All actions will be forced to Node.js 24 on June 2, 2026. This PR updates them proactively.

Closes #139

## Test plan
- [ ] CI workflow passes on this PR
- [ ] PR comment with image tag is posted correctly