### PR TITLE
Fix composer hash + sourced-entry-point bugs at startup

### DIFF
--- a/_sources/scripts/extensions-skins.php
+++ b/_sources/scripts/extensions-skins.php
@@ -177,8 +177,12 @@ $combinedHash = '';
 foreach ($hashFiles as $f) {
     $combinedHash .= md5_file($f);
 }
-exec("mkdir -p $MW_ORIGIN_FILES/config/persistent");
-file_put_contents("$MW_ORIGIN_FILES/config/persistent/.composer-deps-hash", md5($combinedHash) . "\n");
+// The hash file lives at $MW_HOME/.composer-deps-hash, INSIDE the
+// container (not on the bind-mounted $MW_VOLUME). vendor/ is also
+// intra-container, so the hash and the deps it describes share the
+// same lifetime: when the container is recreated, both go away
+// together and run-all.sh correctly re-runs composer. See #141.
+file_put_contents("$MW_HOME/.composer-deps-hash", md5($combinedHash) . "\n");
 
 /**
  * Recursive function to allow for loading a whole chain of YAML files (if

--- a/_sources/scripts/run-all.sh
+++ b/_sources/scripts/run-all.sh
@@ -36,9 +36,19 @@ mkdir -p "$MW_VOLUME"/l10n_cache
 #   - Changed (includes, require, repositories, etc.): copied to $MW_HOME,
 #     hash-checked, composer update runs if changed
 #
+# The hash file lives at $MW_HOME/.composer-deps-hash, INSIDE the
+# container (not on the bind-mounted $MW_VOLUME). This is intentional:
+# vendor/ is also intra-container, so the hash and the deps it
+# describes share the same lifetime. When the container is recreated,
+# both go away together and composer correctly re-runs. Storing the
+# hash on $MW_VOLUME would survive container recreates but vendor/
+# would not, causing the post-recreate start to skip composer with a
+# matching hash and a missing vendor (issue #141).
+#
 # To opt out of runtime composer updates, delete config/composer.local.json.
 # The build-time autoloader will be used as-is.
 COMPOSER_LOCAL="$MW_VOLUME/config/composer.local.json"
+COMPOSER_HASH_FILE="$MW_HOME/.composer-deps-hash"
 NEEDS_COMPOSER=false
 if [ -f "$COMPOSER_LOCAL" ]; then
   NEEDS_COMPOSER=$(php -r '
@@ -65,13 +75,13 @@ if [ "$NEEDS_COMPOSER" = "true" ]; then
     echo md5($h);
   ')
   SAVED_HASH=""
-  if [ -f "$MW_VOLUME/config/persistent/.composer-deps-hash" ]; then
-    SAVED_HASH=$(cat "$MW_VOLUME/config/persistent/.composer-deps-hash" | tr -d '[:space:]')
+  if [ -f "$COMPOSER_HASH_FILE" ]; then
+    SAVED_HASH=$(cat "$COMPOSER_HASH_FILE" | tr -d '[:space:]')
   fi
   if [ "$CURRENT_HASH" != "$SAVED_HASH" ]; then
     echo "Composer dependencies changed, running composer update..."
     composer update --working-dir="$MW_HOME" --no-dev --no-interaction
-    echo "$CURRENT_HASH" > "$MW_VOLUME/config/persistent/.composer-deps-hash"
+    echo "$CURRENT_HASH" > "$COMPOSER_HASH_FILE"
   else
     echo "Composer dependencies unchanged, skipping update."
   fi

--- a/_sources/scripts/run-maintenance-scripts.sh
+++ b/_sources/scripts/run-maintenance-scripts.sh
@@ -184,6 +184,19 @@ run_mw_script() {
 }
 
 ########## Run maintenance scripts ##########
+#
+# This block is the script's "executable" entry point. It only fires
+# when the file is run directly (e.g. `/run-maintenance-scripts.sh &`
+# from run-all.sh) — NOT when the file is sourced for its helper
+# functions (which run-all.sh also does, with `. /run-maintenance-scripts.sh`).
+# Without this guard, sourcing the file silently triggers a full
+# maintenance run as a side effect, racing the explicit invocations
+# elsewhere and producing misleading DB / schema errors in the logs.
+# See issue #143.
+if [ "${BASH_SOURCE[0]}" != "${0}" ]; then
+    return 0
+fi
+
 # Check for valid configuration:
 # - New architecture: config/wikis.yaml (wiki farm config used by FarmConfigLoader.php)
 # - Legacy: config/LocalSettings.php or config/CommonSettings.php

--- a/tests/test_startup_scripts.py
+++ b/tests/test_startup_scripts.py
@@ -1,0 +1,221 @@
+"""Tests for run-all.sh composer logic and run-maintenance-scripts.sh
+source-vs-execute behavior.
+
+These cover the bugs fixed for #141 / #143:
+- Bug A: composer hash file used to be written to a path whose parent
+  directory ($MW_VOLUME/config/persistent) didn't exist on first run,
+  so the redirect failed silently and the hash was never saved →
+  composer ran on every start.
+- Bug B: composer hash file used to live on $MW_VOLUME (bind-mounted,
+  persistent) while vendor/ lives in $MW_HOME (intra-container,
+  ephemeral). After `docker compose up --force-recreate`, vendor/ was
+  wiped but the hash persisted, so the script skipped composer with a
+  matching hash and missing deps.
+- Bug C: run-all.sh sources run-maintenance-scripts.sh to load helper
+  functions, but the file had executable code at the bottom (the
+  "Run maintenance scripts" entry point block) that fired as a side
+  effect of sourcing, racing the explicit invocations elsewhere.
+"""
+
+import os
+import subprocess
+import textwrap
+
+import pytest
+
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ))
+RMS_SCRIPT = os.path.join(
+    REPO_ROOT, "_sources", "scripts", "run-maintenance-scripts.sh",
+)
+
+
+# ---------------------------------------------------------------------------
+# Bug C: run-maintenance-scripts.sh source-vs-execute guard
+# ---------------------------------------------------------------------------
+
+
+def _run_under_stub_env(snippet, mw_volume, www_root, has_config=True,
+                        autoupdate=False):
+    """Run a bash snippet with stub helper functions and a fake canasta
+    filesystem layout. Returns CompletedProcess.
+
+    The snippet is wrapped with stubs for the helper functions that
+    run-maintenance-scripts.sh's top-of-file expects, plus a stub for
+    isFalse / isTrue / etc. so the script's tail can run without
+    /functions.sh being present.
+    """
+    os.makedirs(os.path.join(mw_volume, "config"), exist_ok=True)
+    os.makedirs(www_root, exist_ok=True)
+    if has_config:
+        # Touch wikis.yaml so the entry-point block sees a config
+        open(os.path.join(mw_volume, "config", "wikis.yaml"), "w").close()
+    open(os.path.join(www_root, ".maintenance"), "w").close()
+
+    wrapped = textwrap.dedent("""
+        export MW_VOLUME=%(mw_volume)s
+        export WWW_ROOT=%(www_root)s
+        export MW_AUTOUPDATE=%(autoupdate)s
+        export USE_EXTERNAL_DB=true   # short-circuit waitdatabase
+        export WG_DB_TYPE=mysql
+
+        # Stub helpers normally provided by /functions.sh and elsewhere
+        isFalse() { [ "$1" = "false" ]; }
+        isTrue() { [ "$1" = "true" ]; }
+        get_mediawiki_db_var() { echo ""; }
+        get_mediawiki_variable() { echo ""; }
+
+        # Trace markers — the test asserts on which of these print.
+        run_autoupdate() { echo "STUB:run_autoupdate"; }
+        run_maintenance_scripts() { echo "STUB:run_maintenance_scripts"; }
+        waitdatabase() { echo "STUB:waitdatabase"; return 0; }
+
+        %(snippet)s
+    """) % {
+        "mw_volume": mw_volume,
+        "www_root": www_root,
+        "autoupdate": "true" if autoupdate else "false",
+        "snippet": snippet,
+    }
+    return subprocess.run(
+        ["bash", "-c", wrapped],
+        capture_output=True, text=True,
+    )
+
+
+class TestSourceVsExecuteGuard:
+    """Bug C — sourcing the script must not execute the entry point."""
+
+    def test_sourcing_does_not_run_entry_point(self, tmp_path):
+        snippet = ". %s" % RMS_SCRIPT
+        result = _run_under_stub_env(
+            snippet,
+            mw_volume=str(tmp_path / "mediawiki"),
+            www_root=str(tmp_path / "www"),
+        )
+        # If the entry point fired, it would print "Checking for
+        # configuration..." and call our stub run_maintenance_scripts,
+        # which prints STUB:run_maintenance_scripts. Neither should
+        # appear when only sourced.
+        assert "Checking for configuration" not in result.stdout, (
+            "sourcing fired entry point:\n%s" % result.stdout
+        )
+        assert "STUB:run_maintenance_scripts" not in result.stdout
+        assert "STUB:run_autoupdate" not in result.stdout
+
+    def test_sourcing_still_defines_helper_functions(self, tmp_path):
+        snippet = (
+            ". %s\n"
+            "type waitdatabase >/dev/null && echo HAS:waitdatabase\n"
+            "type run_maintenance_script_if_needed >/dev/null "
+            "&& echo HAS:run_maintenance_script_if_needed\n"
+        ) % RMS_SCRIPT
+        result = _run_under_stub_env(
+            snippet,
+            mw_volume=str(tmp_path / "mediawiki"),
+            www_root=str(tmp_path / "www"),
+        )
+        # The stub-overridden run_autoupdate / waitdatabase / etc. are
+        # defined in our wrapper before the source, so the source's
+        # function definitions overwrite them. After sourcing the
+        # helpers should still resolve to the script's definitions.
+        # We're really just confirming that the source returned cleanly
+        # and the function table is intact.
+        assert "HAS:waitdatabase" in result.stdout
+        assert "HAS:run_maintenance_script_if_needed" in result.stdout
+
+    def test_executing_script_fires_entry_point(self, tmp_path):
+        # When run as a child process (not sourced), the entry point
+        # block must still fire. We use MW_AUTOUPDATE=false so the
+        # script just prints "Auto update script is disabled" and
+        # then calls run_maintenance_scripts (our stub).
+        env = os.environ.copy()
+        mw_volume = tmp_path / "mediawiki"
+        www_root = tmp_path / "www"
+        (mw_volume / "config").mkdir(parents=True)
+        www_root.mkdir()
+        (mw_volume / "config" / "wikis.yaml").touch()
+        (www_root / ".maintenance").touch()
+        env.update({
+            "MW_VOLUME": str(mw_volume),
+            "WWW_ROOT": str(www_root),
+            "MW_AUTOUPDATE": "false",
+            "USE_EXTERNAL_DB": "true",
+            "WG_DB_TYPE": "mysql",
+        })
+        # Inject stubs via a wrapper bash that pre-defines functions,
+        # then EXECUTES (not sources) the script.
+        wrapper = textwrap.dedent("""
+            isFalse() { [ "$1" = "false" ]; }
+            isTrue() { [ "$1" = "true" ]; }
+            get_mediawiki_db_var() { echo ""; }
+            get_mediawiki_variable() { echo ""; }
+            export -f isFalse isTrue get_mediawiki_db_var get_mediawiki_variable
+            bash %s
+        """) % RMS_SCRIPT
+        result = subprocess.run(
+            ["bash", "-c", wrapper],
+            env=env,
+            capture_output=True, text=True,
+        )
+        # When EXECUTED, the entry point should fire — we should see
+        # the "Checking for configuration..." prologue.
+        assert "Checking for configuration" in result.stdout, (
+            "expected entry point to fire when executed directly:\n"
+            "stdout=%s\nstderr=%s" % (result.stdout, result.stderr)
+        )
+
+
+# ---------------------------------------------------------------------------
+# Bugs A + B: composer hash file location
+# ---------------------------------------------------------------------------
+
+
+class TestComposerHashFileLocation:
+    """Bugs A + B — the hash file path is read from `run-all.sh` and
+    must be inside the container ($MW_HOME), not on the bind mount
+    ($MW_VOLUME/config/persistent)."""
+
+    def test_run_all_writes_hash_inside_container(self):
+        """The hash file path must be under $MW_HOME, not $MW_VOLUME."""
+        with open(os.path.join(
+            REPO_ROOT, "_sources", "scripts", "run-all.sh",
+        )) as f:
+            content = f.read()
+
+        # The composer block defines a single source-of-truth variable
+        # for the hash file path. It must point at $MW_HOME, not at
+        # the bind-mounted $MW_VOLUME/config/persistent location.
+        assert 'COMPOSER_HASH_FILE="$MW_HOME/.composer-deps-hash"' in content, (
+            "expected COMPOSER_HASH_FILE to be under $MW_HOME (intra-container)"
+        )
+
+        # Belt and suspenders: confirm the old bind-mount path is not
+        # referenced anywhere in the composer block.
+        composer_block_start = content.find("# Unified composer autoloader")
+        composer_block_end = content.find("/update-docker-gateway.sh")
+        composer_block = content[composer_block_start:composer_block_end]
+        assert ".composer-deps-hash" in composer_block, (
+            "composer block should still reference the hash file"
+        )
+        assert "$MW_VOLUME/config/persistent/.composer-deps-hash" not in composer_block, (
+            "composer block must not write to the bind-mounted path "
+            "anymore (#141)"
+        )
+
+    def test_extensions_skins_writes_baseline_inside_container(self):
+        """The build-time baseline written by extensions-skins.php must
+        also live at $MW_HOME/.composer-deps-hash so it shares the same
+        lifetime as vendor/."""
+        with open(os.path.join(
+            REPO_ROOT, "_sources", "scripts", "extensions-skins.php",
+        )) as f:
+            content = f.read()
+        assert (
+            'file_put_contents("$MW_HOME/.composer-deps-hash"' in content
+        ), "build-time baseline should be written under $MW_HOME"
+        # Old bind-mount baseline path must be gone.
+        assert (
+            "$MW_ORIGIN_FILES/config/persistent/.composer-deps-hash"
+            not in content
+        ), "build-time baseline must not write to $MW_ORIGIN_FILES anymore"


### PR DESCRIPTION
Fixes #141, fixes #143 (items 1 and 2; item 3 is intentional).

## Three related bugs in container startup

### Bug A — composer hash file silently fails to save (#143 item 1)

`run-all.sh` writes the composer dependency hash to `$MW_VOLUME/config/persistent/.composer-deps-hash`, but the `persistent/` directory wasn't guaranteed to exist. The only `mkdir -p` for that path lived inside an SMW-only block that runs *after* the composer block, so on first start the redirect failed silently (no `set -e`) and the hash was never saved. Next start: `SAVED_HASH` still empty, composer runs again. The user-visible symptom: "composer runs every container start, blocking 10-30s."

### Bug B — composer hash outlives the vendor it describes (#141)

Even with Bug A fixed, the hash file lived on `$MW_VOLUME` (bind-mounted, persistent across container recreates) while `vendor/` lived at `$MW_HOME/vendor` (intra-container, wiped on recreate). After `docker compose up --force-recreate`:

- `vendor/` is fresh (build-time deps only, user packages gone)
- hash file persists from before (matches `composer.local.json`)
- script sees "hash matches, skip composer"
- user's required packages are missing → wiki broken

The reproduction in #141 demonstrates this exactly.

**Fix:** move the hash file to `$MW_HOME/.composer-deps-hash`, **inside** the container. Now the hash and the `vendor/` it describes share the same lifetime:

| Scenario | Old behavior | New behavior |
|---|---|---|
| Container restart (same container) | Skip composer (correct) | Skip composer (correct) |
| `docker compose up --force-recreate` | **Skip composer, vendor empty** ❌ | Run composer (correct) |
| User changes `composer.local.json` | Run composer (correct) | Run composer (correct) |

`extensions-skins.php` (which writes the build-time baseline) is updated to write to the same intra-container path, so the first-run hash check still has a baseline to compare against.

### Bug C — sourced entry point fires the maintenance loop (#143 item 2)

`run-all.sh` sources `run-maintenance-scripts.sh` (`. /run-maintenance-scripts.sh`) to load helper functions. But that file had executable code at the bottom — the "Run maintenance scripts" entry point block — that fired as a side effect of sourcing. So:

1. `run-all.sh` sources rms.sh → entry point silently runs: `waitdatabase` + `run_autoupdate` + `run_maintenance_scripts`
2. `run-all.sh` then explicitly calls `run_autoupdate` again at line 177
3. `run-all.sh` forks `/run-maintenance-scripts.sh &` in the background at line 221 → entry point runs a third time

The triple invocation races itself and produces misleading "DB error" / schema validation messages in the logs.

**Fix:** add the standard `[[ "${BASH_SOURCE[0]}" != "${0}" ]]` guard at the entry point so it only fires when the script is executed directly, not when sourced. Verified locally:

```bash
# Sourcing the file no longer prints any of the entry-point markers
$ . _sources/scripts/run-maintenance-scripts.sh   # silent

# Executing the file directly still fires the entry point
$ bash _sources/scripts/run-maintenance-scripts.sh
Checking for configuration...
Auto update script is disabled, MW_AUTOUPDATE is false
```

## Test infrastructure

This PR adds the same pytest scaffolding shape as #148 (which adds the same files for its own `config-subdir-wikis.sh` tests). Whichever PR merges first carries the infra; the second drops the duplicates and keeps just its new test file.

5 new tests in `tests/test_startup_scripts.py`:

- **TestSourceVsExecuteGuard** (3): sourcing the file doesn't fire the entry point, sourcing still defines the helper functions, executing the script directly *does* fire the entry point
- **TestComposerHashFileLocation** (2): `run-all.sh`'s `COMPOSER_HASH_FILE` points at `$MW_HOME` (not the bind-mounted `$MW_VOLUME`), and `extensions-skins.php` writes the build-time baseline at the same intra-container path

## Out of scope

- **#143 item 3 (web installer wizard)** — confirmed with maintainer this is intentional behavior, not a bug
- **`ERROR_SCHEMA_INVALID_KEY`** referenced in #143 was too vague to act on directly without a reproduction; it likely goes away once Bug C is fixed (race conditions tend to surface as schema errors), but there's no specific fix here for that error string

## Test plan

- [x] Bug C reproduced locally before fix (sourcing the file printed entry-point markers)
- [x] Bug C verified fixed (sourcing is silent, executing still fires the entry point)
- [x] Bug A fix verified by reading code path (`$MW_HOME` always exists in the canasta image, no `mkdir` needed)
- [x] Bug B fix verified by tracing the build-time → runtime hash flow
- [x] 5 new pytest tests passing locally
- [x] `bash -n` syntax check on `run-all.sh` and `run-maintenance-scripts.sh`
- [x] `php -l` syntax check on `extensions-skins.php`
- [ ] CI passes
- [ ] Verified end-to-end against a real container build with a user extension that pulls a composer dep, then `--force-recreate` and confirm the dep is reinstalled — out of scope here, would be the natural verification step

## Net change

```
 .github/workflows/tests.yml                 |  25 +++++
 .gitignore                                  |   6 +
 _sources/scripts/extensions-skins.php       |   8 +-
 _sources/scripts/run-all.sh                 |  16 ++-
 _sources/scripts/run-maintenance-scripts.sh |  13 +++
 requirements-test.txt                       |   1 +
 tests/conftest.py                           | 109 +++++++++++++++++++
 tests/test_startup_scripts.py               | 209 ++++++++++++++++++++++++++++++++
 8 files changed, 387 insertions(+), 5 deletions(-)
```

Production code: ~25 lines of changes across 3 files. Test infrastructure + tests: ~360 lines (one-time investment, mostly the conftest.py shared with #148).
