### PR TITLE
Add extra short URL flag

### DIFF
--- a/_sources/canasta/FarmConfigLoader.php
+++ b/_sources/canasta/FarmConfigLoader.php
@@ -7,26 +7,24 @@ if ( !defined( 'MEDIAWIKI' ) ) {
 
 use Symfony\Component\Yaml\Yaml;
 
-// Wiki farm routing mode.
+// Very-short-URL mode for wiki farms.
 //
-//   path     (default) — wikis can be at hostnames or hostname/subdir
-//                        URLs. The first segment of the request path
-//                        is treated as a wiki identifier.
+// When CANASTA_ENABLE_VERY_SHORT_URLS is false (the default), wikis can
+// be at either bare hostnames or hostname/subdir URLs, and page URLs
+// look like https://example.com/wiki1/wiki/PageName. The first segment
+// of the request path is treated as a wiki identifier.
 //
-//   hostname           — wikis must each be on a unique hostname with
-//                        no path component. The request path is left
-//                        intact for MediaWiki to interpret as a page
-//                        title via $wgArticlePath = "/$1" (root-relative
-//                        short URLs). Incompatible with the wiki
-//                        directory feature and with any path-based
-//                        wiki in wikis.yaml.
-$farmRouting = strtolower( getenv( 'CANASTA_FARM_ROUTING' ) ?: 'path' );
-if ( !in_array( $farmRouting, [ 'path', 'hostname' ], true ) ) {
-    throw new Exception(
-        "CANASTA_FARM_ROUTING must be 'path' or 'hostname' "
-        . "(got '" . getenv( 'CANASTA_FARM_ROUTING' ) . "')."
-    );
-}
+// When set to true, the "/wiki" segment goes away — page URLs become
+// root-relative (https://wiki1.example.com/PageName) via
+// $wgArticlePath = "/$1". Each wiki must then be on its own unique
+// hostname with no path component, because there is no longer a path
+// segment available to identify the wiki. Incompatible with the wiki
+// directory feature and with any path-based wiki in wikis.yaml; both
+// conditions are checked below.
+$veryShortUrls = filter_var(
+    getenv( 'CANASTA_ENABLE_VERY_SHORT_URLS' ),
+    FILTER_VALIDATE_BOOLEAN
+);
 
 // Get the original URL from the environment variables
 $original_url = getenv( 'ORIGINAL_URL' );
@@ -66,9 +64,9 @@ if ( !$cliDefaultToFirstWiki ) {
 
 	// Extract the path from the URL, if any.
 	//
-	// In hostname routing mode the path is intentionally left empty
+	// In very-short-URL mode the path is intentionally left empty
 	// — the first URL segment is a page title, not a wiki identifier.
-	if ( $farmRouting !== 'hostname' && isset( $urlComponents['path'] ) ) {
+	if ( !$veryShortUrls && isset( $urlComponents['path'] ) ) {
 		// Split the path into parts
 		$pathParts = explode( '/', trim( $urlComponents['path'], '/' ) );
 
@@ -115,29 +113,29 @@ if ( isset( $wikiConfigurations ) && isset( $wikiConfigurations['wikis'] ) && is
 	foreach ( $wikiConfigurations['wikis'] as $wiki ) {
 		// Check if 'url' and 'id' are set before using them
 		if ( isset( $wiki['url'] ) && isset( $wiki['id'] ) ) {
-			// In hostname routing mode, every wiki must be on its
-			// own unique hostname with no path component. Reject
-			// path-based URLs early with a clear message — the
-			// alternative is silently routing the wrong wiki to
-			// the wrong host. See issue #138.
-			if ( $farmRouting === 'hostname' && strpos( $wiki['url'], '/' ) !== false ) {
+			// In very-short-URL mode, every wiki must be on its own
+			// unique hostname with no path component. Reject path-based
+			// URLs early with a clear message — the alternative is
+			// silently routing the wrong wiki to the wrong host. See
+			// issue #138.
+			if ( $veryShortUrls && strpos( $wiki['url'], '/' ) !== false ) {
 				throw new Exception(
-					"FarmConfigLoader: CANASTA_FARM_ROUTING is set to "
-					. "'hostname' but wiki '" . $wiki['id'] . "' has a "
-					. "path-based URL ('" . $wiki['url'] . "'). Path-based "
-					. "wikis are incompatible with hostname routing — each "
-					. "wiki must be on its own unique hostname. Either "
-					. "remove this wiki, change its URL to a unique "
-					. "hostname, or unset CANASTA_FARM_ROUTING."
+					"FarmConfigLoader: CANASTA_ENABLE_VERY_SHORT_URLS is "
+					. "true but wiki '" . $wiki['id'] . "' has a path-based "
+					. "URL ('" . $wiki['url'] . "'). Path-based wikis are "
+					. "incompatible with very short URLs — each wiki must "
+					. "be on its own unique hostname. Either remove this "
+					. "wiki, change its URL to a unique hostname, or set "
+					. "CANASTA_ENABLE_VERY_SHORT_URLS to false."
 				);
 			}
-			if ( $farmRouting === 'hostname' && isset( $urlToWikiIdMap[$wiki['url']] ) ) {
+			if ( $veryShortUrls && isset( $urlToWikiIdMap[$wiki['url']] ) ) {
 				throw new Exception(
 					"FarmConfigLoader: hostname '" . $wiki['url'] . "' is "
 					. "claimed by both wiki '" . $urlToWikiIdMap[$wiki['url']]
 					. "' and wiki '" . $wiki['id'] . "'. Each wiki must be "
-					. "on a unique hostname when CANASTA_FARM_ROUTING is "
-					. "'hostname'."
+					. "on a unique hostname when CANASTA_ENABLE_VERY_SHORT_URLS "
+					. "is true."
 				);
 			}
 			$urlToWikiIdMap[$wiki['url']] = $wiki['id'];
@@ -150,19 +148,18 @@ if ( isset( $wikiConfigurations ) && isset( $wikiConfigurations['wikis'] ) && is
 	throw new Exception( 'Error: Invalid wiki configurations.' );
 }
 
-// In hostname mode, the wiki directory feature is incompatible —
-// the directory route /wikis would collide with a page titled
+// In very-short-URL mode, the wiki directory feature is incompatible
+// — the directory route /wikis would collide with a page titled
 // "Wikis" on any wiki using root-relative short URLs.
-if ( $farmRouting === 'hostname'
+if ( $veryShortUrls
 	&& getenv( 'CANASTA_ENABLE_WIKI_DIRECTORY' ) === 'true'
 ) {
 	throw new Exception(
-		"FarmConfigLoader: CANASTA_FARM_ROUTING is set to 'hostname' "
-		. "and CANASTA_ENABLE_WIKI_DIRECTORY is set to 'true', but "
-		. "these features are incompatible. The wiki directory is "
-		. "served at /wikis, which collides with a page titled "
-		. "'Wikis' on any wiki using root-relative short URLs. "
-		. "Disable one or the other."
+		"FarmConfigLoader: CANASTA_ENABLE_VERY_SHORT_URLS is true and "
+		. "CANASTA_ENABLE_WIKI_DIRECTORY is true, but these features "
+		. "are incompatible. The wiki directory is served at /wikis, "
+		. "which collides with a page titled 'Wikis' on any wiki using "
+		. "root-relative short URLs. Disable one or the other."
 	);
 }
 
@@ -244,12 +241,12 @@ $wgScriptPath = !empty( $path )
 	? "/$path/w"
 	: "/w";
 
-// In hostname routing mode, page URLs are root-relative (no /wiki/
+// In very-short-URL mode, page URLs are root-relative (no /wiki/
 // segment). $wgScriptPath stays at /w because MediaWiki's own files
 // (api.php, load.php, edit forms, etc.) still live under /w/. The
 // per-wiki Settings.php loaded below can still override $wgArticlePath
 // if a particular wiki needs a different shape.
-if ( $farmRouting === 'hostname' ) {
+if ( $veryShortUrls ) {
 	$wgArticlePath = "/$1";
 } else {
 	$wgArticlePath = !empty( $path )

--- a/_sources/canasta/FarmConfigLoader.php
+++ b/_sources/canasta/FarmConfigLoader.php
@@ -7,6 +7,27 @@ if ( !defined( 'MEDIAWIKI' ) ) {
 
 use Symfony\Component\Yaml\Yaml;
 
+// Wiki farm routing mode.
+//
+//   path     (default) — wikis can be at hostnames or hostname/subdir
+//                        URLs. The first segment of the request path
+//                        is treated as a wiki identifier.
+//
+//   hostname           — wikis must each be on a unique hostname with
+//                        no path component. The request path is left
+//                        intact for MediaWiki to interpret as a page
+//                        title via $wgArticlePath = "/$1" (root-relative
+//                        short URLs). Incompatible with the wiki
+//                        directory feature and with any path-based
+//                        wiki in wikis.yaml.
+$farmRouting = strtolower( getenv( 'CANASTA_FARM_ROUTING' ) ?: 'path' );
+if ( !in_array( $farmRouting, [ 'path', 'hostname' ], true ) ) {
+    throw new Exception(
+        "CANASTA_FARM_ROUTING must be 'path' or 'hostname' "
+        . "(got '" . getenv( 'CANASTA_FARM_ROUTING' ) . "')."
+    );
+}
+
 // Get the original URL from the environment variables
 $original_url = getenv( 'ORIGINAL_URL' );
 $serverName = "";
@@ -43,8 +64,11 @@ if ( !$cliDefaultToFirstWiki ) {
 		}
 	}
 
-	// Extract the path from the URL, if any
-	if ( isset( $urlComponents['path'] ) ) {
+	// Extract the path from the URL, if any.
+	//
+	// In hostname routing mode the path is intentionally left empty
+	// — the first URL segment is a page title, not a wiki identifier.
+	if ( $farmRouting !== 'hostname' && isset( $urlComponents['path'] ) ) {
 		// Split the path into parts
 		$pathParts = explode( '/', trim( $urlComponents['path'], '/' ) );
 
@@ -91,6 +115,31 @@ if ( isset( $wikiConfigurations ) && isset( $wikiConfigurations['wikis'] ) && is
 	foreach ( $wikiConfigurations['wikis'] as $wiki ) {
 		// Check if 'url' and 'id' are set before using them
 		if ( isset( $wiki['url'] ) && isset( $wiki['id'] ) ) {
+			// In hostname routing mode, every wiki must be on its
+			// own unique hostname with no path component. Reject
+			// path-based URLs early with a clear message — the
+			// alternative is silently routing the wrong wiki to
+			// the wrong host. See issue #138.
+			if ( $farmRouting === 'hostname' && strpos( $wiki['url'], '/' ) !== false ) {
+				throw new Exception(
+					"FarmConfigLoader: CANASTA_FARM_ROUTING is set to "
+					. "'hostname' but wiki '" . $wiki['id'] . "' has a "
+					. "path-based URL ('" . $wiki['url'] . "'). Path-based "
+					. "wikis are incompatible with hostname routing — each "
+					. "wiki must be on its own unique hostname. Either "
+					. "remove this wiki, change its URL to a unique "
+					. "hostname, or unset CANASTA_FARM_ROUTING."
+				);
+			}
+			if ( $farmRouting === 'hostname' && isset( $urlToWikiIdMap[$wiki['url']] ) ) {
+				throw new Exception(
+					"FarmConfigLoader: hostname '" . $wiki['url'] . "' is "
+					. "claimed by both wiki '" . $urlToWikiIdMap[$wiki['url']]
+					. "' and wiki '" . $wiki['id'] . "'. Each wiki must be "
+					. "on a unique hostname when CANASTA_FARM_ROUTING is "
+					. "'hostname'."
+				);
+			}
 			$urlToWikiIdMap[$wiki['url']] = $wiki['id'];
 			$wikiIdToConfigMap[$wiki['id']] = $wiki;
 		} else {
@@ -99,6 +148,22 @@ if ( isset( $wikiConfigurations ) && isset( $wikiConfigurations['wikis'] ) && is
 	}
 } else {
 	throw new Exception( 'Error: Invalid wiki configurations.' );
+}
+
+// In hostname mode, the wiki directory feature is incompatible —
+// the directory route /wikis would collide with a page titled
+// "Wikis" on any wiki using root-relative short URLs.
+if ( $farmRouting === 'hostname'
+	&& getenv( 'CANASTA_ENABLE_WIKI_DIRECTORY' ) === 'true'
+) {
+	throw new Exception(
+		"FarmConfigLoader: CANASTA_FARM_ROUTING is set to 'hostname' "
+		. "and CANASTA_ENABLE_WIKI_DIRECTORY is set to 'true', but "
+		. "these features are incompatible. The wiki directory is "
+		. "served at /wikis, which collides with a page titled "
+		. "'Wikis' on any wiki using root-relative short URLs. "
+		. "Disable one or the other."
+	);
 }
 
 // Prepare the key using the server name and the path
@@ -179,9 +244,18 @@ $wgScriptPath = !empty( $path )
 	? "/$path/w"
 	: "/w";
 
-$wgArticlePath = !empty( $path )
-	? "/$path/wiki/$1"
-	: "/wiki/$1";
+// In hostname routing mode, page URLs are root-relative (no /wiki/
+// segment). $wgScriptPath stays at /w because MediaWiki's own files
+// (api.php, load.php, edit forms, etc.) still live under /w/. The
+// per-wiki Settings.php loaded below can still override $wgArticlePath
+// if a particular wiki needs a different shape.
+if ( $farmRouting === 'hostname' ) {
+	$wgArticlePath = "/$1";
+} else {
+	$wgArticlePath = !empty( $path )
+		? "/$path/wiki/$1"
+		: "/wiki/$1";
+}
 $wgCacheDirectory = "$IP/cache/$wikiID";
 $wgUploadDirectory = "$IP/images/$wikiID";
 


### PR DESCRIPTION
Fixes #138.

## Summary

When `CANASTA_ENABLE_VERY_SHORT_URLS=true` is set, `FarmConfigLoader` matches wikis by `HTTP_HOST` alone and never consumes the first URL segment as a wiki identifier. The path is left intact for MediaWiki to interpret as a page title via `$wgArticlePath = "/$1"` — i.e. **root-relative short URLs** (`example.com/Main_Page` instead of `example.com/wiki/Main_Page`). The "/wiki" segment goes away entirely.

The default (`CANASTA_ENABLE_VERY_SHORT_URLS` unset or false) is **byte-identical to the existing behavior**. Every new conditional in this PR is gated on `$veryShortUrls`, so wikis that don't set the env var see no change at all. The new code path is fully opt-in and matches the existing `CANASTA_ENABLE_*` boolean convention.

## Design choices worth flagging

### `$wgScriptPath` stays at `/w` — only `$wgArticlePath` changes

This is the **hybrid approach** documented in [Manual:Short URL](https://www.mediawiki.org/wiki/Manual:Short_URL): we get pretty page URLs without relocating MediaWiki internals to the document root. MediaWiki's own files (`api.php`, `load.php`, edit forms via `index.php?action=edit`, etc.) continue to live under `/w/`.

The alternative — what [Manual:Wiki in site root directory](https://www.mediawiki.org/wiki/Manual:Wiki_in_site_root_directory) describes — would set `$wgScriptPath = ""` and require rewriting `/api.php` → `/w/api.php`, `/index.php` → `/w/index.php`, etc. plus dealing with the action-name conflicts the doc warns about. We don't need any of that complexity. Apache's existing `.htaccess` catch-all already routes `/Main_Page` → `/w/index.php`, MediaWiki reads `REQUEST_URI` and matches it against `$wgArticlePath = "/$1"` to extract the title, and we're done.

| URL kind | Default (very short URLs off) | `CANASTA_ENABLE_VERY_SHORT_URLS=true` |
|---|---|---|
| Page view | `example.com/wiki/Main_Page` | `example.com/Main_Page` |
| Edit form | `example.com/w/index.php?title=Main_Page&action=edit` | `example.com/w/index.php?title=Main_Page&action=edit` |
| API | `example.com/w/api.php` | `example.com/w/api.php` |
| Resources | `example.com/w/load.php` | `example.com/w/load.php` |
| Special pages | `example.com/wiki/Special:RecentChanges` | `example.com/Special:RecentChanges` |
| Image (private) | `example.com/w/images/...` (img_auth) | `example.com/w/images/...` (img_auth) |
| Public assets | `example.com/public_assets/...` | `example.com/public_assets/...` |

### `$wgArticlePath` is set automatically, not left to per-wiki Settings.php

The whole point of opting in is to get root-relative URLs. Making the user wire it up by hand in their per-wiki `Settings.php` would be busywork. `FarmConfigLoader` sets `$wgArticlePath = "/$1"` automatically when very-short-URL mode is on. Per-wiki settings still load *after* `FarmConfigLoader` and can still override if needed.

### Faux-boolean env var (matches existing convention)

`CANASTA_ENABLE_VERY_SHORT_URLS` is read with `filter_var(..., FILTER_VALIDATE_BOOLEAN)`, the standard PHP idiom for env-var-as-bool, matching how other `CANASTA_ENABLE_*` flags work in this codebase. There are only two real states being modeled (the `/wiki` segment is either there or it isn't), so a string enum would be over-engineering.

## Constraints (validated at request time)

When very-short-URL mode is on, two configurations are rejected with descriptive exception messages:

### 1. No path-based wikis allowed

```
FarmConfigLoader: CANASTA_ENABLE_VERY_SHORT_URLS is true but wiki 'docs' has
a path-based URL ('example.com/docs'). Path-based wikis are incompatible with
very short URLs — each wiki must be on its own unique hostname. Either remove
this wiki, change its URL to a unique hostname, or set
CANASTA_ENABLE_VERY_SHORT_URLS to false.
```

Mixing hostname-only and path-based wikis in the same farm is genuinely incoherent — a request to `example.com/docs/Main_Page` is ambiguous between "the docs wiki, page Main_Page" and "the example.com wiki, page docs/Main_Page". There's no way for `FarmConfigLoader` to disambiguate, so we fail fast at startup.

### 2. Wiki directory feature is incompatible

```
FarmConfigLoader: CANASTA_ENABLE_VERY_SHORT_URLS is true and
CANASTA_ENABLE_WIKI_DIRECTORY is true, but these features are incompatible.
The wiki directory is served at /wikis, which collides with a page titled
'Wikis' on any wiki using root-relative short URLs. Disable one or the other.
```

The wiki directory route `/wikis` would collide with a page named "Wikis" once root-relative short URLs are active.

### Where the exceptions actually fire

Both validations fire at `FarmConfigLoader` load time during MediaWiki bootstrap. A misconfigured container will fail to start cleanly: `run-all.sh`'s maintenance step exits 123 because the bootstrap-time `getMediawikiSettings.php` call can't read `$wgDBtype` past the exception. The PHP fatal error and the `FarmConfigLoader` exception message are clearly visible in `docker compose logs web` either way.

The proper place for this kind of misconfiguration to be caught is **at the CLI layer** — `canasta config set` / `canasta add` should refuse the incompatible operations before they even land in `.env` / `wikis.yaml`. That's the Canasta-Ansible follow-up tracked as CanastaWiki/Canasta-Ansible#50 (PR #52). The runtime validation here is the safety net for hand-edited configs and direct YAML imports that bypass the CLI.

## Manual test plan

Built a fresh canasta image via `--build-from` against a local test instance configured with `CANASTA_ENABLE_VERY_SHORT_URLS=true` and ran a 14-case URL matrix:

| # | Test | Result |
|---|---|---|
| 1 | very-short-URL: `GET /Main_Page` | 200 ✓ |
| 2 | very-short-URL: `GET /` | 200 ✓ |
| 3 | very-short-URL: `GET /Special:RecentChanges` | 200 ✓ |
| 4 | very-short-URL: `GET /Special:Block` (slash in title) | 200 ✓ |
| 5 | very-short-URL: `api.php` siteinfo | `articlepath: /$1`, `scriptpath: /w` ✓ |
| 6 | very-short-URL: `GET /w/load.php?modules=startup` | 200 ✓ |
| 7 | very-short-URL: `GET /w/index.php?title=...&action=edit` | 200 ✓ |
| 8 | very-short-URL: `GET /favicon.ico` (real file) | 200 ✓ |
| 9 | very-short-URL: `GET /robots.txt` (Canasta `robots.php`) | 200 ✓ |
| 10 | regression: img_auth.php anon→403, authed→200 | ✓ (#147 still works) |
| 11 | regression: public_assets serves | ✓ (#148 still works) |
| 12 | error: very-short-URL + path-based wiki | exception fires with exact text |
| 13 | error: very-short-URL + wiki directory | exception fires with exact text |
| 14 | regression: **default mode** `/wiki/Main_Page` | 200 ✓ (**backward compat**) |

The matrix above was originally run against the prior `CANASTA_FARM_ROUTING=hostname` form of this PR. The rename to `CANASTA_ENABLE_VERY_SHORT_URLS=true` is purely a name and value-shape change; the URL behavior, the validation paths, and the exception text (modulo the env var name) are identical.

## Dependencies / follow-ups

- **Canasta-Ansible** needs a one-line addition to `roles/orchestrator/files/compose/docker-compose.yml` to plumb `CANASTA_ENABLE_VERY_SHORT_URLS` through to the web container's environment, alongside the existing `CANASTA_ENABLE_WIKI_DIRECTORY` line. Without it, setting the env var via the CLI doesn't reach the running PHP and the feature is silent. Tracked as CanastaWiki/Canasta-Ansible#50 / PR #52.
- **Canasta-Ansible** should also add config-time validation in `canasta add` / `canasta config set` to catch the two incompatible-feature combinations before they ever land in a running container. Same follow-up PR.
- **PHPUnit unit tests are not added in this PR.** `FarmConfigLoader.php` is a procedural script with global state and would need a substantial refactor to be unit-testable. That refactor is itself a regression risk and is the wrong scope for an additive opt-in feature change. #130 covers the test-coverage work as a separate, deliberate effort.

## Test plan

- [x] 14-case URL matrix on a real canasta image build
- [x] Regression checks for #147 (img_auth) and #148 (public_assets)
- [x] Both error paths verified with exact exception text from the logs
- [x] Default mode (env var unset) verified backward-compatible
- [x] CI passes
- [x] Canasta-Ansible follow-up filed (#50 / PR #52)

## Net change

Single file: `_sources/canasta/FarmConfigLoader.php`. ~25 lines of new logic, ~25 lines of comments explaining the design choices and the constraint rationale.
