### PR TITLE
Fix img_auth.php for private wiki farms with sub-path wikis

### DIFF
--- a/_sources/scripts/config-subdir-wikis.sh
+++ b/_sources/scripts/config-subdir-wikis.sh
@@ -95,16 +95,17 @@ APACHE
         # inside the subdirectory's .htaccess, so the paths match
         # as-is (e.g. w/img_auth.php/, not docs/w/img_auth.php/).
         #
-        # The img_auth.php rule uses [END] instead of [L] to prevent
-        # the rewritten URL from re-entering the ruleset. After the
-        # passthrough, REQUEST_URI contains PATH_INFO (e.g.
-        # /w/img_auth.php/a/ab/File.png) which doesn't exist as a
-        # filesystem path, so the catch-all "not a file" rule would
-        # otherwise redirect to index.php.
+        # Both rest.php and img_auth.php rules use [END] instead of
+        # [L] to prevent the rewritten URL from re-entering the
+        # ruleset. After the passthrough, REQUEST_URI contains
+        # PATH_INFO (e.g. /w/img_auth.php/a/ab/File.png) which
+        # doesn't exist as a filesystem path, so the catch-all
+        # "not a file" rule would otherwise redirect to index.php.
         #
         # The catch-all index.php rules DO need the prefix because
         # the symlink routes $wiki_path/w/ → the real MW /w/.
-        sed -e "s|img_auth.php/ - \[L\]|img_auth.php/ - [END]|" \
+        sed -e "s|rest.php/ - \[L\]|rest.php/ - [END]|" \
+            -e "s|img_auth.php/ - \[L\]|img_auth.php/ - [END]|" \
             -e "s|^/*\$ %{DOCUMENT_ROOT}/w/index.php|/*\$ %{DOCUMENT_ROOT}/$wiki_path/w/index.php|" \
             -e "s|^\\(.*\\)\$ %{DOCUMENT_ROOT}/w/index.php|\\1\$ %{DOCUMENT_ROOT}/$wiki_path/w/index.php|" \
             "$WWW_ROOT/.htaccess" > "$WWW_ROOT/$wiki_path/.htaccess"

--- a/_sources/scripts/config-subdir-wikis.sh
+++ b/_sources/scripts/config-subdir-wikis.sh
@@ -87,8 +87,24 @@ APACHE
         mkdir -p "$WWW_ROOT/$wiki_path"
         ln -sf "$MW_HOME" "$WWW_ROOT/$wiki_path"
 
-        sed -e "s|w/rest.php/|$wiki_path/w/rest.php/|g" \
-            -e "s|w/img_auth.php/|$wiki_path/w/img_auth.php/|g" \
+        # Generate the subdirectory .htaccess from the root .htaccess.
+        #
+        # The rest.php and img_auth.php passthrough rules are NOT
+        # prefixed with the wiki path. Apache has already stripped
+        # the subdirectory prefix by the time it evaluates rules
+        # inside the subdirectory's .htaccess, so the paths match
+        # as-is (e.g. w/img_auth.php/, not docs/w/img_auth.php/).
+        #
+        # The img_auth.php rule uses [END] instead of [L] to prevent
+        # the rewritten URL from re-entering the ruleset. After the
+        # passthrough, REQUEST_URI contains PATH_INFO (e.g.
+        # /w/img_auth.php/a/ab/File.png) which doesn't exist as a
+        # filesystem path, so the catch-all "not a file" rule would
+        # otherwise redirect to index.php.
+        #
+        # The catch-all index.php rules DO need the prefix because
+        # the symlink routes $wiki_path/w/ → the real MW /w/.
+        sed -e "s|img_auth.php/ - \[L\]|img_auth.php/ - [END]|" \
             -e "s|^/*\$ %{DOCUMENT_ROOT}/w/index.php|/*\$ %{DOCUMENT_ROOT}/$wiki_path/w/index.php|" \
             -e "s|^\\(.*\\)\$ %{DOCUMENT_ROOT}/w/index.php|\\1\$ %{DOCUMENT_ROOT}/$wiki_path/w/index.php|" \
             "$WWW_ROOT/.htaccess" > "$WWW_ROOT/$wiki_path/.htaccess"

--- a/tests/test_config_subdir_wikis.py
+++ b/tests/test_config_subdir_wikis.py
@@ -114,7 +114,8 @@ class TestSubdirWikiPlumbing:
         assert "docs/w/img_auth.php/" not in docs_htaccess
         assert "w/rest.php/" in docs_htaccess
         assert "docs/w/rest.php/" not in docs_htaccess
-        # img_auth.php uses [END] to prevent catch-all re-entry
+        # Both use [END] to prevent catch-all re-entry
+        assert "rest.php/ - [END]" in docs_htaccess
         assert "img_auth.php/ - [END]" in docs_htaccess
         # The catch-all index.php rules DO need the prefix
         assert "docs/w/index.php" in docs_htaccess

--- a/tests/test_config_subdir_wikis.py
+++ b/tests/test_config_subdir_wikis.py
@@ -107,8 +107,17 @@ class TestSubdirWikiPlumbing:
         _, _ = script_runner([{"id": "docs", "url": "example.com/docs"}])
         ws = script_runner.workspace
         docs_htaccess = (ws["www_root"] / "docs" / ".htaccess").read_text()
-        assert "docs/w/img_auth.php/" in docs_htaccess
-        assert "docs/w/rest.php/" in docs_htaccess
+        # The img_auth.php and rest.php passthrough rules must NOT be
+        # prefixed with the wiki path. Inside the subdirectory, Apache
+        # has already stripped the prefix before evaluating .htaccess.
+        assert "w/img_auth.php/" in docs_htaccess
+        assert "docs/w/img_auth.php/" not in docs_htaccess
+        assert "w/rest.php/" in docs_htaccess
+        assert "docs/w/rest.php/" not in docs_htaccess
+        # img_auth.php uses [END] to prevent catch-all re-entry
+        assert "img_auth.php/ - [END]" in docs_htaccess
+        # The catch-all index.php rules DO need the prefix
+        assert "docs/w/index.php" in docs_htaccess
 
     def test_subdir_wiki_emits_img_auth_aliases(self, script_runner):
         cfg, _ = script_runner([{"id": "docs", "url": "example.com/docs"}])


### PR DESCRIPTION
## Summary

Fix `img_auth.php` returning 301 redirect instead of serving images for private wiki farms with sub-path wikis (e.g. `example.com/docs/`).

**Root cause:** `config-subdir-wikis.sh` prefixed `img_auth.php` and `rest.php` passthrough rules with the wiki path in the subdirectory `.htaccess`. Inside the subdirectory, Apache has already stripped the prefix, so the rules never matched.

**Fix:**
- Stop prefixing `img_auth.php` and `rest.php` passthrough rules in subdirectory `.htaccess`
- Use `[END]` instead of `[L]` for `img_auth.php` to prevent catch-all re-entry (the rewritten PATH_INFO doesn't exist as a file on disk)

**Verified:** manually editing the subdirectory `.htaccess` in a running Kamins instance with 4 private sub-path wikis fixed image serving immediately.

Fixes #154

## Test plan

- [x] Existing tests updated and all 16 pass
- [x] Test asserts prefixed paths are NOT in subdirectory `.htaccess`
- [x] Test asserts `[END]` flag on `img_auth.php` rule
- [ ] Manual test: private wiki farm with sub-path wikis serves images correctly
