### PR TITLE
Append non-standard port to $wgDBserver for external DB

### DIFF
--- a/_sources/canasta/CanastaDefaultSettings.php
+++ b/_sources/canasta/CanastaDefaultSettings.php
@@ -81,13 +81,15 @@ $wgPingback = false;
 $wgUseInstantCommons = false;
 
 # Database connection (from environment, can be overridden by config/LocalSettings.php)
+# $wgDBport is intentionally not set — MediaWiki's MySQL driver ignores
+# it (only the PostgreSQL driver honors $wgDBport). Non-standard ports
+# are communicated via host:port on $wgDBserver.
 $wgDBtype = "mysql";
 $wgDBserver = getenv( 'MYSQL_HOST' ) ?: 'db';
 $_dbPort = getenv( 'MYSQL_PORT' ) ?: '3306';
 if ( $_dbPort !== '3306' ) {
 	$wgDBserver .= ':' . $_dbPort;
 }
-$wgDBport = $_dbPort;
 $wgDBuser = getenv( 'MYSQL_USER' ) ?: 'root';
 $wgDBpassword = getenv( 'MYSQL_PASSWORD' ) ?: 'mediawiki';
 

--- a/_sources/canasta/CanastaDefaultSettings.php
+++ b/_sources/canasta/CanastaDefaultSettings.php
@@ -83,7 +83,11 @@ $wgUseInstantCommons = false;
 # Database connection (from environment, can be overridden by config/LocalSettings.php)
 $wgDBtype = "mysql";
 $wgDBserver = getenv( 'MYSQL_HOST' ) ?: 'db';
-$wgDBport = getenv( 'MYSQL_PORT' ) ?: '3306';
+$_dbPort = getenv( 'MYSQL_PORT' ) ?: '3306';
+if ( $_dbPort !== '3306' ) {
+	$wgDBserver .= ':' . $_dbPort;
+}
+$wgDBport = $_dbPort;
 $wgDBuser = getenv( 'MYSQL_USER' ) ?: 'root';
 $wgDBpassword = getenv( 'MYSQL_PASSWORD' ) ?: 'mediawiki';
 


### PR DESCRIPTION
## Summary

When `MYSQL_PORT` is not 3306, append it to `$wgDBserver` as `host:port`. MediaWiki's MySQL driver ignores `$wgDBport` — it only uses `$wgDBserver` for the connection string.

Without this fix, external databases on non-standard ports (e.g., `MYSQL_HOST=10.0.0.1 MYSQL_PORT=3307`) silently connect to port 3306 and fail.

Found during testing of Canasta-Ansible external DB support (#211).

Fixes #161
