### PR TITLE
Fix immutable version tag not publishing on release commits

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -47,6 +47,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # fetch-depth: 2 so HEAD~1 is available in the "Generate tags"
+          # step below, which inspects the diff between the two newest
+          # commits to detect VERSION-file changes. Default fetch-depth
+          # of 1 leaves HEAD~1 unreachable, silently suppresses the
+          # Canasta version tag, and caused 1.3.7 to publish without
+          # its immutable tag.
+          fetch-depth: 2
       -
         name: Generate tags
         id: generate


### PR DESCRIPTION
## Problem

The version-tag detection added in #160 uses `git diff HEAD~1` to notice VERSION-file changes and append the Canasta version tag (`canasta-base:1.3.X`) to REGISTRY_TAGS on master builds. But \`actions/checkout@v4\` defaults to `fetch-depth: 1`, which leaves `HEAD~1` unreachable — \`git diff\` fails silently, \`grep\` matches nothing, the condition is always false, and the tag is never appended.

Caught when the Release 1.3.7 merge (#163) built the image and pushed `:latest:1.43.8-latest`/etc. but skipped the immutable `canasta-base:1.3.7` tag. Had to recover by manually pushing a git tag `1.3.7` so the tag-triggered path of the same workflow could pick it up.

## Fix

Set `fetch-depth: 2` on the Docker workflow's checkout so `HEAD~1` is available. One line + a comment documenting why.

## Verification

Next VERSION bump on master should auto-publish its `canasta-base:X.Y.Z` tag without a manual git-tag-push step.