### PR TITLE
Add PHP_MEMORY_LIMIT env var (closes #165)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -189,6 +189,7 @@ ENV MW_AUTOUPDATE=true \
 	PHP_MAX_INPUT_VARS=1000 \
 	PHP_MAX_EXECUTION_TIME=60 \
 	PHP_MAX_INPUT_TIME=60 \
+	PHP_MEMORY_LIMIT=256M \
 	PM_MAX_CHILDREN=25 \
 	PM_START_SERVERS=10 \
 	PM_MIN_SPARE_SERVERS=5 \
@@ -199,8 +200,8 @@ ENV MW_AUTOUPDATE=true \
 
 COPY _sources/configs/mediawiki.conf /etc/apache2/sites-enabled/
 COPY _sources/configs/status.conf /etc/apache2/mods-available/
-COPY _sources/configs/php_error_reporting.ini _sources/configs/php_upload_max_filesize.ini /etc/php/8.2/cli/conf.d/
-COPY _sources/configs/php_error_reporting.ini _sources/configs/php_upload_max_filesize.ini /etc/php/8.2/fpm/conf.d/
+COPY _sources/configs/php_error_reporting.ini _sources/configs/php_upload_max_filesize.ini _sources/configs/php_memory_limit.ini /etc/php/8.2/cli/conf.d/
+COPY _sources/configs/php_error_reporting.ini _sources/configs/php_upload_max_filesize.ini _sources/configs/php_memory_limit.ini /etc/php/8.2/fpm/conf.d/
 COPY _sources/configs/php_max_input_vars.ini _sources/configs/php_max_input_vars.ini /etc/php/8.2/fpm/conf.d/
 COPY _sources/configs/php_timeouts.ini /etc/php/8.2/fpm/conf.d/
 COPY _sources/configs/php-fpm-www.conf /etc/php/8.2/fpm/pool.d/www.conf

--- a/_sources/configs/php_memory_limit.ini
+++ b/_sources/configs/php_memory_limit.ini
@@ -1,0 +1,4 @@
+; Override default PHP memory_limit (compiled default is 128M, which
+; real workloads — esp. complex permission graphs and SMW rebuilds —
+; can exhaust). Operator can override via PHP_MEMORY_LIMIT env var.
+memory_limit="${PHP_MEMORY_LIMIT}"


### PR DESCRIPTION
## Summary

Add a `PHP_MEMORY_LIMIT` env var alongside the other five `PHP_*` knobs already in the Dockerfile. Default raised from PHP's compiled-in 128M to **256M** so realistic workloads don't fatal out of the box.

## Why now

Real deployments are hitting the 128M ceiling. The most visible recent case: a Canasta wiki was returning empty 200s from `api.php` for hours — turned out to be `HtmlCacheUpdater` fataling inside the permission resolution path at 128M (a `UserGetRights` hook accidentally re-entering itself). Without `PHP_MEMORY_LIMIT` exposed as an env var, the operator's only options were `ini_set('memory_limit', '512M')` in `Settings.php` (per-instance, easily forgotten) or mounting a custom `php.ini` fragment via `docker-compose.override.yml` (per-instance, awkward).

The other five PHP knobs (`PHP_UPLOAD_MAX_FILESIZE`, `PHP_POST_MAX_SIZE`, `PHP_MAX_INPUT_VARS`, `PHP_MAX_EXECUTION_TIME`, `PHP_MAX_INPUT_TIME`) were already exposed. `PHP_MEMORY_LIMIT` was just the one knob that wasn't.

## Changes

- **`Dockerfile`**: Add `PHP_MEMORY_LIMIT=256M` to the `ENV` block, alongside the other `PHP_*` defaults.
- **`Dockerfile`**: Add `php_memory_limit.ini` to the `COPY` lines for both `cli/conf.d/` and `fpm/conf.d/` (matches how `php_upload_max_filesize.ini` is wired — applies to both PHP execution contexts).
- **`_sources/configs/php_memory_limit.ini`** (new): one-line override using PHP's built-in `${ENV_VAR}` substitution syntax in INI files. Identical pattern to `php_upload_max_filesize.ini` and the other env-driven INI fragments.

## Default-value choice

256M is a comfortable middle ground:
- Well above 128M (the value that's been hit in practice).
- Well below 512M-1G (which is only needed for heavy SMW rebuilds — and the JobRunner already runs maintenance scripts with its own `MW_JOB_RUNNER_MEMORY_LIMIT=512M` flag, so that path isn't bound by this knob).
- Operators can raise it via `PHP_MEMORY_LIMIT` in the instance's `.env` without touching files in the image.

## Test plan

- [ ] Build the image and `docker compose exec web php -i | grep memory_limit` reports `256M`.
- [ ] Set `PHP_MEMORY_LIMIT=512M` in `.env`, restart, confirm PHP picks up the override.
- [ ] CLI path also honors it: `docker compose exec web php -r 'echo ini_get("memory_limit");'` returns the same value.

Closes #165.
