### PR TITLE
Add ghostscript and xpdf-utils to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,8 @@ RUN set x; \
 	lsb-release \
 	imagemagick  \
 	librsvg2-bin \
+	ghostscript \
+	xpdf-utils \
 	python3-pygments \
 	patch \
 	vim \


### PR DESCRIPTION
Those are required by the PdfHandler extension (https://www.mediawiki.org/wiki/Extension:PdfHandler#Pre-requisites).