### PR TITLE
fix: wait for LocalSettings.php with external DB to prevent exit 123

### DIFF
--- a/_sources/scripts/run-maintenance-scripts.sh
+++ b/_sources/scripts/run-maintenance-scripts.sh
@@ -30,21 +30,21 @@ waitdatabase() {
     if [ "$WG_DB_TYPE" != "mysql" ]; then
         if [ -z "$WG_DB_TYPE" ] && isTrue "$USE_EXTERNAL_DB"; then
             echo >&2 "LocalSettings.php not yet generated — install.php may still be running. Retrying..."
-            sleep 2
-            WG_DB_TYPE=$(get_mediawiki_db_var wgDBtype)
-            if [ "$WG_DB_TYPE" = "mysql" ]; then
-                echo >&2 "Database type now available, continuing."
-            else
-                for i in $(seq 1 30); do
-                    sleep 2
-                    WG_DB_TYPE=$(get_mediawiki_db_var wgDBtype)
-                    if [ "$WG_DB_TYPE" = "mysql" ]; then
-                        echo >&2 "Database type detected after ${i} retries."
-                        break
-                    fi
-                    echo >&2 "Waiting for LocalSettings.php (attempt $i/30)..."
-                done
-            fi
+            for i in {1..31}; do
+                sleep 2
+                WG_DB_TYPE=$(get_mediawiki_db_var wgDBtype)
+                if [ "$WG_DB_TYPE" = "mysql" ]; then
+                    echo >&2 "Database type detected after ${i} attempt(s)."
+                    # LocalSettings.php now exists; the DB vars snapshotted at
+                    # script start were empty, so reload the rest to match.
+                    WG_DB_SERVER=$(get_mediawiki_db_var wgDBserver)
+                    WG_DB_NAME=$(get_mediawiki_db_var wgDBname)
+                    WG_DB_USER=$(get_mediawiki_db_var wgDBuser)
+                    WG_DB_PASSWORD=$(get_mediawiki_db_var wgDBpassword)
+                    break
+                fi
+                echo >&2 "Waiting for LocalSettings.php (attempt $i/31)..."
+            done
         fi
         if [ "$WG_DB_TYPE" != "mysql" ]; then
             echo >&2 "Unsupported database type ($WG_DB_TYPE)"

--- a/_sources/scripts/run-maintenance-scripts.sh
+++ b/_sources/scripts/run-maintenance-scripts.sh
@@ -28,9 +28,29 @@ waitdatabase() {
     fi
 
     if [ "$WG_DB_TYPE" != "mysql" ]; then
-        echo >&2 "Unsupported database type ($WG_DB_TYPE)"
-        rm "$WWW_ROOT/.maintenance"
-        exit 123
+        if [ -z "$WG_DB_TYPE" ] && isTrue "$USE_EXTERNAL_DB"; then
+            echo >&2 "LocalSettings.php not yet generated — install.php may still be running. Retrying..."
+            sleep 2
+            WG_DB_TYPE=$(get_mediawiki_db_var wgDBtype)
+            if [ "$WG_DB_TYPE" = "mysql" ]; then
+                echo >&2 "Database type now available, continuing."
+            else
+                for i in $(seq 1 30); do
+                    sleep 2
+                    WG_DB_TYPE=$(get_mediawiki_db_var wgDBtype)
+                    if [ "$WG_DB_TYPE" = "mysql" ]; then
+                        echo >&2 "Database type detected after ${i} retries."
+                        break
+                    fi
+                    echo >&2 "Waiting for LocalSettings.php (attempt $i/30)..."
+                done
+            fi
+        fi
+        if [ "$WG_DB_TYPE" != "mysql" ]; then
+            echo >&2 "Unsupported database type ($WG_DB_TYPE)"
+            rm "$WWW_ROOT/.maintenance"
+            exit 123
+        fi
     fi
 
     if isFalse "$USE_EXTERNAL_DB"; then


### PR DESCRIPTION
## Problem

When USE_EXTERNAL_DB=true on Docker Compose, canasta create fails because the container entrypoint checks $WG_DB_TYPE before install.php has generated LocalSettings.php.

The container starts → get_mediawiki_db_var → getMediawikiSettings.php checks LocalSettings.php → not found → returns empty → $WG_DB_TYPE is empty → exit 123

## Fix

When $WG_DB_TYPE is empty and USE_EXTERNAL_DB=true, retry for up to ~62 seconds to give install.php time to create LocalSettings.php.

## Testing

Production-style deployment: EC2 with rootless Podman, Canasta CLI v4.2.0, image 3.5.10, external Aurora MySQL RDS.

Closes #175