### PR TITLE
fix: guard PHP-FPM log dir setup against unset PHP_LOG_DIR

### DIFF
--- a/_sources/scripts/run-all.sh
+++ b/_sources/scripts/run-all.sh
@@ -111,15 +111,21 @@ else
     chmod -R g=rwX "$APACHE_LOG_DIR"
 fi
 
-echo "Checking permissions of PHP-FPM log dir $PHP_LOG_DIR..."
-if ! mountpoint -q -- "$PHP_LOG_DIR/"; then
-    mkdir -p "$MW_VOLUME/log/php-fpm"
-    rsync -avh --ignore-existing "$PHP_LOG_DIR/" "$MW_VOLUME/log/php-fpm/"
-    mv "$PHP_LOG_DIR" "${PHP_LOG_DIR}_old"
-    ln -s "$MW_VOLUME/log/php-fpm" "$PHP_LOG_DIR"
+# Skip when PHP_LOG_DIR is unset — an empty path makes mountpoint test "/"
+# (always a mountpoint) and then runs chgrp/chmod on '', which errors every boot.
+if [ -z "$PHP_LOG_DIR" ]; then
+    echo "PHP_LOG_DIR is unset — skipping PHP-FPM log dir setup."
 else
-    chgrp -R "$WWW_GROUP" "$PHP_LOG_DIR"
-    chmod -R g=rwX "$PHP_LOG_DIR"
+    echo "Checking permissions of PHP-FPM log dir $PHP_LOG_DIR..."
+    if ! mountpoint -q -- "$PHP_LOG_DIR/"; then
+        mkdir -p "$MW_VOLUME/log/php-fpm"
+        rsync -avh --ignore-existing "$PHP_LOG_DIR/" "$MW_VOLUME/log/php-fpm/"
+        mv "$PHP_LOG_DIR" "${PHP_LOG_DIR}_old"
+        ln -s "$MW_VOLUME/log/php-fpm" "$PHP_LOG_DIR"
+    else
+        chgrp -R "$WWW_GROUP" "$PHP_LOG_DIR"
+        chmod -R g=rwX "$PHP_LOG_DIR"
+    fi
 fi
 
 config_subdir_wikis() {


### PR DESCRIPTION
## Summary

Fixes #174. The PHP-FPM log-dir block in `run-all.sh` references `PHP_LOG_DIR`, which is never defined in the image. The empty value made the `mountpoint` test run against `/` (always a mountpoint), so the `else` branch ran `chgrp -R www-data ''` and `chmod -R g=rwX ''` — printing `cannot access '': No such file or directory` on **every** container boot since #420.

## Fix

Guard the block so it is a no-op when `PHP_LOG_DIR` is unset. The Apache and MediaWiki log-dir blocks are unchanged (their vars *are* defined and they work).

Chose to guard rather than delete because PHP-FPM logs are a legitimate future input for the Observability profile — tracked in CanastaWiki/Canasta-CLI#839. The guard stops the boot-time noise now and preserves the scaffolding for that wire-up.

## Testing

`bash -n` clean. With `PHP_LOG_DIR` unset the block logs a single skip line and runs no `chgrp/chmod`; the errors no longer appear in boot logs.
