### PR TITLE
fix(monitor-directories): detect host-side dir events without the inotify ISDIR flag

### DIFF
--- a/_sources/scripts/maintenance-scripts/monitor-directories.sh
+++ b/_sources/scripts/maintenance-scripts/monitor-directories.sh
@@ -3,12 +3,6 @@ set -x
 
 . /functions.sh
 
-# Disable directory monitoring
-if isTrue "$DISABLE_DIRECTORY_MONITOR"; then
-  echo "Directory monitoring is disabled via DISABLE_DIRECTORY_MONITOR"
-  exit 0
-fi
-
 userexts="$MW_HOME/user-extensions"
 extensions="$MW_HOME/extensions"
 canexts="$MW_HOME/canasta-extensions"
@@ -17,40 +11,64 @@ userskins="$MW_HOME/user-skins"
 skins="$MW_HOME/skins"
 canskins="$MW_HOME/canasta-skins"
 
-#  - Detects activity changes inside user-extensions and user-skins.
-#  - Adds symlinks from the those folders to the appropriate correspondent folders, user-extensions to extensions and user-skins to skins.
-#  - As a fallback, the moment the extension is removed or moved from user-extensions it will revert back by adding a symlink to the extension
-#    located in canasta-extensions.
+#  - Detects changes inside user-extensions / user-skins and maintains
+#    symlinks into extensions / skins (user-extensions -> extensions,
+#    user-skins -> skins).
+#  - When an entry is removed or moved out, reverts to the bundled copy in
+#    canasta-extensions / canasta-skins if present, otherwise removes the link.
+#
+# Event handling does not trust inotify's ISDIR flag. Docker Desktop on macOS
+# propagates host-side bind-mount events without it, so a directory create
+# arrives as a bare CREATE. We stat the source path to decide whether to link
+# instead of matching on the flag, which keeps live detection working there.
 
-inotifywait -m -e create,moved_to,delete,moved_from --format '%e:%f' -- "$userexts" |
+# Reads "event:file" lines (inotifywait --format '%e:%f') from stdin and
+# maintains the symlinks for one directory pair.
+# Args: <user_dir> <link_dir> <canonical_dir>
+handle_dir_events() {
+  local user_dir=$1 link_dir=$2 canonical_dir=$3
+  local event file
   while IFS=: read -r event file; do
+    [ -n "$file" ] || continue
     case $event in
-      CREATE,ISDIR|MOVED_TO,ISDIR)
-        ln -sfn -- "$userexts/$file" "$extensions/$file" ;;
-      DELETE,ISDIR|MOVED_FROM,ISDIR)
-        echo "event: ${event} file: ${file}";
-        if [ -e "$canexts/$file" ]; then
-          ln -sfn -- "$canexts/$file" "$extensions/$file"
-        else
-          rm -f -- "$extensions/$file"
+      CREATE*|MOVED_TO*)
+        # Only link directories (extensions/skins are dirs); ignore files.
+        [ -d "$user_dir/$file" ] && ln -sfn -- "$user_dir/$file" "$link_dir/$file"
+        ;;
+      DELETE*|MOVED_FROM*)
+        # Only touch links we manage; leave unrelated entries alone.
+        if [ -L "$link_dir/$file" ] || [ ! -e "$link_dir/$file" ]; then
+          if [ -e "$canonical_dir/$file" ]; then
+            ln -sfn -- "$canonical_dir/$file" "$link_dir/$file"
+          else
+            rm -f -- "$link_dir/$file"
+          fi
         fi
         ;;
     esac
   done
+}
 
-inotifywait -m -e create,moved_to,delete,moved_from --format '%e:%f' -- "$userskins" |
-  while IFS=: read -r event file; do
-    case $event in
-      CREATE,ISDIR|MOVED_TO,ISDIR)
-        ln -sfn -- "$userskins/$file" "$skins/$file" ;;
-      DELETE,ISDIR|MOVED_FROM,ISDIR)
-        echo "event: ${event} file: ${file}";
-        if [ -e "$canskins/$file" ]; then
-          ln -sfn -- "$canskins/$file" "$skins/$file"
-        else
-          rm -f -- "$skins/$file"
-        fi
-        ;;
+# Watch one directory for changes and feed events to handle_dir_events.
+# Args: <user_dir> <link_dir> <canonical_dir>
+watch_dir() {
+  inotifywait -m -e create,moved_to,delete,moved_from --format '%e:%f' -- "$1" |
+    handle_dir_events "$1" "$2" "$3"
+}
 
-    esac
-  done
+# When sourced (e.g. by the tests) stop here so the watchers do not run.
+if [ "${BASH_SOURCE[0]}" != "${0}" ]; then
+  return 0
+fi
+
+# Disable directory monitoring
+if isTrue "$DISABLE_DIRECTORY_MONITOR"; then
+  echo "Directory monitoring is disabled via DISABLE_DIRECTORY_MONITOR"
+  exit 0
+fi
+
+# Watch both directories concurrently. The previous sequential form left the
+# skins watcher unreachable because `inotifywait -m` never returns.
+watch_dir "$userexts" "$extensions" "$canexts" &
+watch_dir "$userskins" "$skins" "$canskins" &
+wait

--- a/tests/test_startup_scripts.py
+++ b/tests/test_startup_scripts.py
@@ -219,3 +219,131 @@ class TestComposerHashFileLocation:
             "$MW_ORIGIN_FILES/config/persistent/.composer-deps-hash"
             not in content
         ), "build-time baseline must not write to $MW_ORIGIN_FILES anymore"
+
+
+# ---------------------------------------------------------------------------
+# monitor-directories.sh: live extension/skin symlink maintenance
+# ---------------------------------------------------------------------------
+
+
+MONITOR_SCRIPT = os.path.join(
+    REPO_ROOT, "_sources", "scripts", "maintenance-scripts",
+    "monitor-directories.sh",
+)
+
+
+def _handle_events(events, user_dir, link_dir, canonical_dir):
+    """Source monitor-directories.sh and feed synthetic inotify event
+    lines ("event:file", as produced by --format '%e:%f') to its
+    handle_dir_events function. Sourcing returns early via the
+    BASH_SOURCE guard, so no real inotifywait runs. The missing
+    /functions.sh is harmless (the script has no `set -e`)."""
+    snippet = textwrap.dedent("""
+        . %(script)s >/dev/null 2>&1
+        set +x
+        printf '%%s\\n' %(events)s \
+            | handle_dir_events "%(user)s" "%(link)s" "%(canon)s"
+    """) % {
+        "script": MONITOR_SCRIPT,
+        "events": " ".join("'%s'" % e for e in events),
+        "user": user_dir,
+        "link": link_dir,
+        "canon": canonical_dir,
+    }
+    return subprocess.run(
+        ["bash", "-c", snippet], capture_output=True, text=True,
+    )
+
+
+class TestMonitorDirectories:
+    """handle_dir_events must maintain symlinks based on a stat of the
+    source path, NOT on inotify's ISDIR flag. Docker Desktop on macOS
+    strips ISDIR from host-side bind-mount events, so a directory create
+    arrives as a bare CREATE; the watcher must still link it."""
+
+    def _layout(self, tmp_path):
+        user = tmp_path / "user-extensions"
+        link = tmp_path / "extensions"
+        canon = tmp_path / "canasta-extensions"
+        for d in (user, link, canon):
+            d.mkdir()
+        return user, link, canon
+
+    def test_bare_create_links_directory(self, tmp_path):
+        """The macOS case: CREATE without ISDIR still links a dir."""
+        user, link, canon = self._layout(tmp_path)
+        (user / "MyExt").mkdir()
+        _handle_events(["CREATE:MyExt"], user, link, canon)
+        target = link / "MyExt"
+        assert target.is_symlink(), "bare CREATE did not create the symlink"
+        assert os.path.realpath(target) == str(user / "MyExt")
+
+    def test_isdir_create_links_directory(self, tmp_path):
+        """The Linux case stays working: CREATE,ISDIR links a dir."""
+        user, link, canon = self._layout(tmp_path)
+        (user / "MyExt").mkdir()
+        _handle_events(["CREATE,ISDIR:MyExt"], user, link, canon)
+        assert (link / "MyExt").is_symlink()
+
+    def test_moved_to_links_directory(self, tmp_path):
+        """MOVED_TO (with or without ISDIR) behaves like CREATE."""
+        user, link, canon = self._layout(tmp_path)
+        (user / "MyExt").mkdir()
+        _handle_events(["MOVED_TO:MyExt"], user, link, canon)
+        assert (link / "MyExt").is_symlink()
+
+    def test_create_ignores_plain_file(self, tmp_path):
+        """A non-directory entry must never be symlinked (e.g. .gitkeep)."""
+        user, link, canon = self._layout(tmp_path)
+        (user / "README").write_text("x")
+        _handle_events(["CREATE:README"], user, link, canon)
+        assert not (link / "README").exists(), (
+            "a plain file should not be linked into extensions/"
+        )
+
+    def test_delete_reverts_to_bundled(self, tmp_path):
+        """Removing a user dir that shadows a bundled one reverts the
+        link to the bundled copy."""
+        user, link, canon = self._layout(tmp_path)
+        (canon / "MyExt").mkdir()
+        # Pre-existing user override link, now the source is gone.
+        (link / "MyExt").symlink_to(user / "MyExt")
+        _handle_events(["DELETE:MyExt"], user, link, canon)
+        target = link / "MyExt"
+        assert target.is_symlink()
+        assert os.path.realpath(target) == str(canon / "MyExt"), (
+            "delete should revert the link to the bundled extension"
+        )
+
+    def test_delete_removes_link_when_no_bundled(self, tmp_path):
+        """Removing a purely-custom user dir removes the dangling link."""
+        user, link, canon = self._layout(tmp_path)
+        (link / "MyExt").symlink_to(user / "MyExt")
+        _handle_events(["DELETE:MyExt"], user, link, canon)
+        assert not (link / "MyExt").exists() and \
+            not (link / "MyExt").is_symlink(), (
+            "delete with no bundled copy should remove the link"
+        )
+
+    def test_delete_leaves_unmanaged_entry_alone(self, tmp_path):
+        """A delete event must not clobber a real (non-symlink) entry we
+        did not create."""
+        user, link, canon = self._layout(tmp_path)
+        real = link / "Keep"
+        real.mkdir()
+        (real / "marker").write_text("x")
+        _handle_events(["DELETE:Keep"], user, link, canon)
+        assert real.is_dir() and (real / "marker").exists(), (
+            "delete must not touch an unmanaged real directory"
+        )
+
+    def test_sourcing_does_not_launch_watchers(self, tmp_path):
+        """Sourcing the script (for its functions) must not start
+        inotifywait — the BASH_SOURCE guard returns first."""
+        result = subprocess.run(
+            ["bash", "-c",
+             ". %s >/dev/null 2>&1; type handle_dir_events >/dev/null "
+             "&& echo HAS:handle_dir_events" % MONITOR_SCRIPT],
+            capture_output=True, text=True,
+        )
+        assert "HAS:handle_dir_events" in result.stdout


### PR DESCRIPTION
Fixes #178.

## Problem

The live extension/skin watcher (`/maintenance-scripts/monitor-directories.sh`) did not pick up custom extensions/skins added from the **host** on Docker Desktop for macOS. The directory had to be present at container start (so `create-symlinks.sh` links it) or the container had to be restarted.

**Root cause:** the watcher only matched events tagged with inotify's `ISDIR` flag. Docker Desktop on macOS propagates host-side bind-mount events *without* it, so a directory create arrives as a bare `CREATE` and matched none of the cases. Verified in a live container:

```
HOST-side  mkdir → RAW[CREATE]:Foo          # no ISDIR
CONTAINER  mkdir → RAW[CREATE,ISDIR]:Foo    # has ISDIR
```

**Secondary bug:** the two watchers ran sequentially, but `inotifywait -m` never returns, so the **skins watcher never started** — on Linux as well as macOS (only one `inotifywait` process runs in a live container).

## Changes

- **Stat instead of trusting `ISDIR`.** Match the bare event names (`CREATE*`/`MOVED_TO*`/`DELETE*`/`MOVED_FROM*`) and decide via `[ -d ]` on the source path. A `[ -L ]` guard on the delete path keeps unmanaged entries untouched.
- **Run both watchers concurrently** (`&` + `wait`) so the skins watcher actually starts.
- **Testability:** extract the loop body into `handle_dir_events()` behind a `BASH_SOURCE` guard (matching `run-maintenance-scripts.sh`), so it can be unit-tested without launching `inotifywait`.
- **Tests:** add `TestMonitorDirectories` (8 cases) — bare `CREATE` links a dir (macOS), `CREATE,ISDIR` still links (Linux), `MOVED_TO`, plain files ignored, delete reverts-to-bundled / removes-link / leaves-unmanaged-alone, and sourcing doesn't launch watchers.

## Linux safety

Behavior is preserved: directory events still carry `ISDIR` and are matched; bare events (files) stat as non-directories and are skipped exactly as before. The new branches only fire for bare events, which on Linux are non-directories and become no-ops.

## Verification

- All 29 tests pass (21 existing + 8 new).
- Confirmed the new tests are meaningful: the old ISDIR-only logic fails the bare-`CREATE` case; the new stat-based logic passes it.
- `bash -n` clean.
