### PR TITLE
fix(entrypoint): heal config/persistent ownership before run_autoupdate

### DIFF
--- a/_sources/scripts/run-all.sh
+++ b/_sources/scripts/run-all.sh
@@ -179,6 +179,11 @@ if [ -n "$MW_SECRET_KEY" ] || [ -e "$MW_VOLUME/config/LocalSettings.php" ] || [ 
   SMW_JSON="$MW_VOLUME/config/persistent/.smw.json"
   if [ -f "$MW_HOME/extensions/SemanticMediaWiki/extension.json" ]; then
     mkdir -p "$MW_VOLUME/config/persistent"
+    # Heal config/persistent ownership before run_autoupdate so setupStore.php
+    # (invoked by update.php) can write .smw.json. The recursive make_dir_writable
+    # on $MW_VOLUME runs later and in the background — too late for setupStore on
+    # this start. Scoped to just this directory to stay cheap.
+    make_dir_writable "$MW_VOLUME/config/persistent"
     SMW_WIKIS_BEFORE=""
     if [ -f "$SMW_JSON" ]; then
       SMW_WIKIS_BEFORE=$(php -r "

--- a/tests/test_startup_scripts.py
+++ b/tests/test_startup_scripts.py
@@ -18,6 +18,7 @@ These cover the bugs fixed for #141 / #143:
 """
 
 import os
+import re
 import subprocess
 import textwrap
 
@@ -219,6 +220,32 @@ class TestComposerHashFileLocation:
             "$MW_ORIGIN_FILES/config/persistent/.composer-deps-hash"
             not in content
         ), "build-time baseline must not write to $MW_ORIGIN_FILES anymore"
+
+
+class TestPersistentDirWritableBeforeAutoupdate:
+    """#172 — config/persistent must be made writable by the web user
+    *before* run_autoupdate, so setupStore.php (invoked by update.php) can
+    persist .smw.json. The recursive make_dir_writable on $MW_VOLUME runs
+    later and in the background, too late to help SMW on the current start."""
+
+    def test_persistent_healed_before_run_autoupdate(self):
+        with open(os.path.join(
+            REPO_ROOT, "_sources", "scripts", "run-all.sh",
+        )) as f:
+            content = f.read()
+
+        heal = content.find('make_dir_writable "$MW_VOLUME/config/persistent"')
+        assert heal != -1, (
+            "expected a targeted make_dir_writable on $MW_VOLUME/config/persistent"
+        )
+
+        # Match the call line itself, not the surrounding comments that
+        # also mention run_autoupdate.
+        call = re.search(r"^\s*run_autoupdate\s*$", content, re.MULTILINE)
+        assert call is not None, "run_autoupdate call should exist"
+        assert heal < call.start(), (
+            "config/persistent must be healed before run_autoupdate, not after"
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

`setupStore.php` (invoked by `update.php` during `run_autoupdate`) writes `config/persistent/.smw.json`. If that directory's ownership is disturbed so it is not writable by the web user, `setupStore` cannot persist the file. SMW then logs `.smw.json is not writable`, the before/after snapshot treats the wiki as freshly set up, and `smw_needs_rebuild=true` ("newly set up → run rebuildData") fires on **every** container start.

The recursive `make_dir_writable` on `$MW_VOLUME` heals the ownership, but:
- it runs **after** `run_autoupdate` (too late for `setupStore` on the current start), and
- only at container **start** — never during a `canasta maintenance update` exec. So repeatedly running `maintenance update` without a restart never recovers, and SMW re-runs setup each time.

Incident (2026-06-10): on a gitops-managed instance, a `git rm --cached config/persistent/.smw.json` + `git pull --rebase` re-checked-out the file owned by the operator (not `www-data`). SMW went into a perpetual "newly set up → needs rebuild" state across repeated `maintenance update` runs. Manual recovery was `chgrp www-data .smw.json && chmod 664` + restart.

## Fix

Make `config/persistent/` writable by the web user **before** `run_autoupdate`, scoped to just that directory (reusing the selective `make_dir_writable` helper, which only touches files not already writable) so it stays cheap. The deferred/backgrounded recursive heal on the full volume is unchanged.

## Test

Adds a static-source test asserting the heal appears before the `run_autoupdate` call in `run-all.sh`. Full suite: 30 passed.

Closes #172