### PR TITLE
fix(settings): guard canastaLoadConfigYaml against null $wgSettings

### DIFF
--- a/_sources/canasta/CanastaDefaultSettings.php
+++ b/_sources/canasta/CanastaDefaultSettings.php
@@ -164,6 +164,12 @@ function isEnvTrue( $name ): bool {
  */
 function canastaLoadConfigYaml( $configDir ) {
 	global $wgSettings;
+	if ( $wgSettings === null ) {
+		// Reached outside a normal request bootstrap (e.g. PHPUnit's
+		// extension-discovery runner sources LocalSettings.php without
+		// initialising Setup.php, so $wgSettings is never created).
+		return;
+	}
 	$yamlFiles = glob( $configDir . '/*.yaml' );
 	if ( $yamlFiles === false || !is_array( $yamlFiles ) ) {
 		return;


### PR DESCRIPTION
## Problem

Running PHPUnit unit tests on a Canasta-built MediaWiki (`composer phpunit:unit`, core or extension) fatals during MediaWiki's extension-discovery step:

```
PHP Fatal error:  Uncaught Error: Call to a member function loadFile() on null
  in /var/www/mediawiki/w/CanastaDefaultSettings.php:173
```

MediaWiki's unit-test runner avoids initialising `Setup.php`, but still enumerates installed extensions to find their tests by spawning `tests/phpunit/getPHPUnitExtensionsAndSkins.php`, which sources `LocalSettings.php`. That requires `CanastaDefaultSettings.php`, which calls `canastaLoadConfigYaml()` → `$wgSettings->loadFile()`. Since `$wgSettings` is normally initialised by `Setup.php` (bypassed here), it is `null` and the call fatals.

## Fix

Return early from `canastaLoadConfigYaml` when `$wgSettings === null` — config-YAML loading is meaningless on that non-request code path. No effect on normal request bootstrap, where `Setup.php` has already created `$wgSettings`.

PHP lint clean; existing test suite passes (29). No test added — the repo has no PHP unit-test harness yet (tracked in #130 / #46).

Closes #167