### PR TITLE
Make the MediaWiki version a build-time ARG

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -66,8 +66,9 @@ jobs:
           # Date
           BDATE=$(date +%Y%m%d)
 
-          # Extract MW version from Dockerfile
-          MEDIAWIKI_VERSION=$(sed -nr 's/MW_CORE_VERSION\=([0-9\.]+)/\1/p' Dockerfile | sed "s/ \\\//" | sed "s/\t//")
+          # Extract MW version from the MW_CORE_VERSION default in the Dockerfile
+          # (matches whether it is declared via ARG or ENV; ignores any prefix and trailing chars)
+          MEDIAWIKI_VERSION=$(sed -nr 's/.*MW_CORE_VERSION=([0-9]+\.[0-9]+\.[0-9]+).*/\1/p' Dockerfile | head -n1)
           # Extract MW major version (like 1.35)
           MEDIAWIKI_MAJOR_VERSION=${MEDIAWIKI_VERSION%.*}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,11 @@ FROM debian:12.8 AS base
 LABEL maintainers=""
 LABEL org.opencontainers.image.source=https://github.com/CanastaWiki/CanastaBase
 
-ENV MW_VERSION=REL1_43 \
-	MW_CORE_VERSION=1.43.8 \
+ARG MW_VERSION=REL1_43
+ARG MW_CORE_VERSION=1.43.8
+
+ENV MW_VERSION=${MW_VERSION} \
+	MW_CORE_VERSION=${MW_CORE_VERSION} \
 	WWW_ROOT=/var/www/mediawiki \
 	MW_HOME=/var/www/mediawiki/w \
 	MW_LOG=/var/log/mediawiki \


### PR DESCRIPTION
Make the bundled MediaWiki version overridable at build time, so the image can be built against a non-default MediaWiki version or branch (e.g. a non-LTS release or `master`) without editing the Dockerfile. Routine version bumps still edit the `MW_CORE_VERSION` default; this just adds a `--build-arg` override on top of it.

## Changes
- `Dockerfile`: convert `MW_VERSION` and `MW_CORE_VERSION` from `ENV` to `ARG`, promoted back to `ENV`. Defaults are unchanged, so a plain build is identical and the OCI `wiki.canasta.mediawiki.version`/`.branch` labels still resolve. `docker build --build-arg MW_CORE_VERSION=... --build-arg MW_VERSION=...` can now target a different MediaWiki version or branch (including `master`) without editing the Dockerfile.
- `.github/workflows/docker-image.yml`: update the `MW_CORE_VERSION` tag parser to read the version regardless of the `ARG`/`ENV` prefix (verified it still emits the current `1.43.8`).

No version bump — this is a build-mechanism change with no functional difference to the default image. hadolint passes.

Should merge before the 1.3.10 release PR (#183), which builds on this.

Closes #184
