### PR TITLE
Fail the image build on git clone/checkout errors (#189)

### DIFF
--- a/_sources/scripts/extensions-skins.php
+++ b/_sources/scripts/extensions-skins.php
@@ -66,8 +66,21 @@ foreach (['extensions', 'skins'] as $type) {
             $gitCloneCmd .= "$repository $MW_HOME/canasta-$type/$name";
             $gitCheckoutCmd = "cd $MW_HOME/canasta-$type/$name && git checkout -q $commit";
 
-            exec($gitCloneCmd);
-            exec($gitCheckoutCmd);
+            // Fail the build on a git failure instead of shipping the
+            // extension at the wrong revision. A clone failure leaves nothing;
+            // a failed checkout (e.g. an unreachable pinned commit) silently
+            // leaves the extension on the clone's default branch or branch
+            // HEAD, which ships code that was never intended.
+            exec($gitCloneCmd, $cloneOutput, $cloneReturnCode);
+            if ($cloneReturnCode !== 0) {
+                fwrite(STDERR, "ERROR: git clone failed for $type/$name (exit $cloneReturnCode). Aborting the build.\n");
+                exit($cloneReturnCode);
+            }
+            exec($gitCheckoutCmd, $checkoutOutput, $checkoutReturnCode);
+            if ($checkoutReturnCode !== 0) {
+                fwrite(STDERR, "ERROR: git checkout $commit failed for $type/$name (exit $checkoutReturnCode); the pinned commit may be unreachable. Aborting the build.\n");
+                exit($checkoutReturnCode);
+            }
         }
 
         if ($patches !== null) {


### PR DESCRIPTION
Fixes #189.

`extensions-skins.php` cloned and checked out every non-bundled extension/skin with `exec()` and ignored the exit codes:

```php
exec($gitCloneCmd);
exec($gitCheckoutCmd);
```

So an unreachable pinned commit (`fatal: reference is not a tree: <commit>`) let the build continue, leaving the extension on the clone's default branch or branch HEAD — shipping code that was never pinned. This drifted unnoticed across releases (EmbedVideo was silently on `master`; see CanastaWiki/RecommendedRevisions#19/#20).

This mirrors the Composer fail-fast guardrail (#186/#187): a `git clone` or `git checkout` failure now aborts the build with a clear message.

## Sequencing
This will (correctly) fail any build with an unreachable pin. The current dead pins are fixed in CanastaWiki/RecommendedRevisions#20 — **merge that, and point Canasta's `contents.yaml` at the fixed RecommendedRevisions revision, before merging this**, or Canasta builds will fail on the existing pins.

## Not in scope
When `repository:` is set the clone ignores the `branch:` field (full clone of the default branch); honoring `branch:` for repository-specified extensions is a separate follow-up noted in #189.