### PR TITLE
Fail the build/boot on composer and git errors

### DIFF
--- a/_sources/scripts/extensions-skins.php
+++ b/_sources/scripts/extensions-skins.php
@@ -49,7 +49,11 @@ foreach (['extensions', 'skins'] as $type) {
             $packageName = $data['composer-name'];
             $packageVersion = $data['composer-version'] ?? null;
             $packageString = $packageVersion ? "$packageName:$packageVersion" : $packageName;
-            exec("composer require $packageString --working-dir=$MW_HOME --no-interaction");
+            exec("composer require $packageString --working-dir=$MW_HOME --no-interaction", $requireOutput, $requireReturnCode);
+            if ($requireReturnCode !== 0) {
+                fwrite(STDERR, "ERROR: composer require $packageString failed for $type/$name (exit $requireReturnCode). Aborting the build.\n");
+                exit($requireReturnCode);
+            }
         }
 
         if (!$bundled && !($data['composer-name'] ?? null)) {
@@ -86,7 +90,11 @@ foreach (['extensions', 'skins'] as $type) {
         if ($patches !== null) {
             foreach ($patches as $patch) {
                 $gitApplyCmd = "cd $MW_HOME/canasta-$type/$name && git apply /tmp/$patch";
-                exec($gitApplyCmd);
+                exec($gitApplyCmd, $applyOutput, $applyReturnCode);
+                if ($applyReturnCode !== 0) {
+                    fwrite(STDERR, "ERROR: git apply /tmp/$patch failed for $type/$name (exit $applyReturnCode); the extension would ship unpatched. Aborting the build.\n");
+                    exit($applyReturnCode);
+                }
             }
         }
 
@@ -97,7 +105,11 @@ foreach (['extensions', 'skins'] as $type) {
                     $composerIncludes[] = "$type/$name/composer.json";
                 } elseif ($step === "git submodule update") {
                     $submoduleUpdateCmd = "cd $MW_HOME/canasta-$type/$name && git submodule update --init";
-                    exec($submoduleUpdateCmd);
+                    exec($submoduleUpdateCmd, $submoduleOutput, $submoduleReturnCode);
+                    if ($submoduleReturnCode !== 0) {
+                        fwrite(STDERR, "ERROR: git submodule update failed for $type/$name (exit $submoduleReturnCode). Aborting the build.\n");
+                        exit($submoduleReturnCode);
+                    }
                 }
             }
         }

--- a/_sources/scripts/run-all.sh
+++ b/_sources/scripts/run-all.sh
@@ -80,8 +80,13 @@ if [ "$NEEDS_COMPOSER" = "true" ]; then
   fi
   if [ "$CURRENT_HASH" != "$SAVED_HASH" ]; then
     echo "Composer dependencies changed, running composer update..."
-    composer update --working-dir="$MW_HOME" --no-dev --no-interaction
-    echo "$CURRENT_HASH" > "$COMPOSER_HASH_FILE"
+    # Only record the new hash if the update succeeded; otherwise the next start
+    # would skip composer and boot with a broken/stale vendor tree.
+    if composer update --working-dir="$MW_HOME" --no-dev --no-interaction; then
+      echo "$CURRENT_HASH" > "$COMPOSER_HASH_FILE"
+    else
+      echo "composer update failed; leaving the dependency hash unchanged so it retries on next start." >&2
+    fi
   else
     echo "Composer dependencies unchanged, skipping update."
   fi


### PR DESCRIPTION
Fail the build/boot on composer and git errors

- run-all.sh: only record the composer dependency hash when composer update
  succeeds, so a failed update retries on next start instead of booting a
  stale/broken vendor tree.
- extensions-skins.php: abort the image build on a failed composer require,
  git apply, or git submodule update (completes the clone/checkout
  fail-fast behavior).

Part of #192.
