### PR TITLE
Make Apache/htaccess config generation idempotent across restarts

### DIFF
--- a/_sources/scripts/config-subdir-wikis.sh
+++ b/_sources/scripts/config-subdir-wikis.sh
@@ -22,6 +22,23 @@ set -e
 WIKIS_YAML="${WIKIS_YAML:-$MW_VOLUME/config/wikis.yaml}"
 APACHE_CONF="${APACHE_CONF:-/etc/apache2/apache2.conf}"
 
+# A container restart reuses the same apache2.conf, so strip any block we
+# appended on a previous run before regenerating it. Without this the rewrite
+# rules and aliases accumulate one duplicate copy per start.
+MARKER_BEGIN="# BEGIN canasta-subdir-wikis (managed by config-subdir-wikis.sh)"
+MARKER_END="# END canasta-subdir-wikis"
+if grep -qF "$MARKER_BEGIN" "$APACHE_CONF" 2>/dev/null; then
+    stripped="$(mktemp)"
+    sed "/^# BEGIN canasta-subdir-wikis/,/^# END canasta-subdir-wikis/d" "$APACHE_CONF" > "$stripped"
+    cat "$stripped" > "$APACHE_CONF"
+    rm -f "$stripped"
+fi
+
+# Accumulate this run's directives in a buffer, then append them once, wrapped
+# in the markers above, so the next run can find and remove them.
+GENERATED_CONF="$(mktemp)"
+trap 'rm -f "$GENERATED_CONF"' EXIT
+
 # Walk wikis.yaml and emit one TAB-separated "id<TAB>url" line per wiki.
 # Assumes the canonical canasta wikis.yaml format where each wiki entry
 # starts with "- id: <id>" followed by "  url: <url>" (and optionally
@@ -66,12 +83,12 @@ while IFS=$'\t' read -r wiki_id wiki_url; do
     # safe for multi-host farms — only the matching host's request paths
     # get routed to that wiki's storage directory.
     if [ -n "$wiki_path" ]; then
-        cat >> "$APACHE_CONF" <<APACHE
+        cat >> "$GENERATED_CONF" <<APACHE
 RewriteCond %{HTTP_HOST} ^${host_re}\$ [NC]
 RewriteRule ^/${wiki_path}/public_assets/(.*)\$ /mediawiki/public_assets/${wiki_id}/\$1 [L]
 APACHE
     else
-        cat >> "$APACHE_CONF" <<APACHE
+        cat >> "$GENERATED_CONF" <<APACHE
 RewriteCond %{HTTP_HOST} ^${host_re}\$ [NC]
 RewriteRule ^/public_assets/(.*)\$ /mediawiki/public_assets/${wiki_id}/\$1 [L]
 APACHE
@@ -110,7 +127,16 @@ APACHE
             -e "s|^\\(.*\\)\$ %{DOCUMENT_ROOT}/w/index.php|\\1\$ %{DOCUMENT_ROOT}/$wiki_path/w/index.php|" \
             "$WWW_ROOT/.htaccess" > "$WWW_ROOT/$wiki_path/.htaccess"
 
-        echo "Alias /$wiki_path/w/images/ /var/www/mediawiki/w/img_auth.php/" >> "$APACHE_CONF"
-        echo "Alias /$wiki_path/w/images /var/www/mediawiki/w/img_auth.php" >> "$APACHE_CONF"
+        echo "Alias /$wiki_path/w/images/ /var/www/mediawiki/w/img_auth.php/" >> "$GENERATED_CONF"
+        echo "Alias /$wiki_path/w/images /var/www/mediawiki/w/img_auth.php" >> "$GENERATED_CONF"
     fi
 done < <(parse_wikis)
+
+# Append this run's directives as a single marked block.
+if [ -s "$GENERATED_CONF" ]; then
+    {
+        printf '%s\n' "$MARKER_BEGIN"
+        cat "$GENERATED_CONF"
+        printf '%s\n' "$MARKER_END"
+    } >> "$APACHE_CONF"
+fi

--- a/_sources/scripts/create-storage-dirs.sh
+++ b/_sources/scripts/create-storage-dirs.sh
@@ -19,5 +19,9 @@ for db_name in "${ids[@]}"; do
     chown $(stat -c '%u' $MW_VOLUME/public_assets):$WWW_GROUP $MW_VOLUME/public_assets/$db_name
 done
 
-# Protect Images Directory from Internet Access
-echo "Deny from All" >> $MW_VOLUME/images/.htaccess 
+# Protect Images Directory from Internet Access (only add the rule once; this
+# script runs on every container start)
+htaccess="$MW_VOLUME/images/.htaccess"
+if ! grep -qxF "Deny from All" "$htaccess" 2>/dev/null; then
+    echo "Deny from All" >> "$htaccess"
+fi

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,6 @@
 """Shared fixtures for CanastaBase tests."""
 
 import os
-import shutil
 import subprocess
 
 import pytest

--- a/tests/test_config_subdir_wikis.py
+++ b/tests/test_config_subdir_wikis.py
@@ -77,6 +77,21 @@ class TestApacheRewriteGeneration:
         assert cfg.count("RewriteRule ^/public_assets/(.*)$") == 1
         assert cfg.count("RewriteRule ^/docs/public_assets/(.*)$") == 1
 
+    def test_rerun_does_not_duplicate_directives(self, script_runner):
+        # A container restart reuses the same apache2.conf; running the
+        # script a second time must replace its block, not append a copy.
+        wikis = [
+            {"id": "main", "url": "localhost"},
+            {"id": "docs", "url": "localhost/docs"},
+        ]
+        script_runner(wikis)
+        cfg, result = script_runner(wikis)
+        assert result.returncode == 0, result.stderr
+        assert cfg.count("RewriteRule ^/public_assets/(.*)$") == 1
+        assert cfg.count("RewriteRule ^/docs/public_assets/(.*)$") == 1
+        assert cfg.count("Alias /docs/w/images/ ") == 1
+        assert cfg.count("# BEGIN canasta-subdir-wikis") == 1
+
 
 class TestSubdirWikiPlumbing:
     """The pre-#144 logic for subdir wikis (preserved by the rewrite)."""


### PR DESCRIPTION
Make Apache/htaccess config generation idempotent across restarts

- config-subdir-wikis.sh: write the generated Apache directives as a single
  marker-delimited block that is stripped and regenerated each run, so a
  container restart no longer accumulates duplicate rewrite/alias blocks.
- create-storage-dirs.sh: add the images/.htaccess deny rule only once.
- tests: add a rerun regression test; drop an unused import.

Part of #192.
