### PR TITLE
fix(public_assets): parse indented wikis.yaml in config-subdir-wikis.sh

### DIFF
--- a/_sources/scripts/config-subdir-wikis.sh
+++ b/_sources/scripts/config-subdir-wikis.sh
@@ -40,18 +40,20 @@ GENERATED_CONF="$(mktemp)"
 trap 'rm -f "$GENERATED_CONF"' EXIT
 
 # Walk wikis.yaml and emit one TAB-separated "id<TAB>url" line per wiki.
-# Assumes the canonical canasta wikis.yaml format where each wiki entry
-# starts with "- id: <id>" followed by "  url: <url>" (and optionally
-# more fields). awk tracks the current wiki and flushes when it sees
-# the next entry or end-of-file.
+# Each wiki entry is a "- id: <id>" list item followed by a "url: <url>"
+# key. Leading indentation is tolerated: both the flat block style
+# (list item at column 0) and the nested style (list item indented under
+# "wikis:") are valid YAML and appear in the wild, so the anchors match
+# either. awk tracks the current wiki and flushes when it sees the next
+# entry or end-of-file.
 parse_wikis() {
     awk '
-        /^- id:/ {
+        /^[ \t]*-[ \t]+id:/ {
             if (id != "" && url != "") { print id "\t" url }
             id = $3
             url = ""
         }
-        /^  url:/ { url = $2 }
+        /^[ \t]*url:/ { url = $2 }
         END { if (id != "" && url != "") print id "\t" url }
     ' "$WIKIS_YAML"
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,17 +60,23 @@ def workspace(tmp_path):
     }
 
 
-def write_wikis(wikis_yaml, wikis):
-    """Write a wikis list to wikis.yaml in the canonical canasta format.
+def write_wikis(wikis_yaml, wikis, indent=0):
+    """Write a wikis list to wikis.yaml.
 
     `wikis` is a list of dicts with at least `id` and `url` keys.
+
+    `indent` is the number of spaces before each "- id:" list item.
+    Both the flat block style (indent=0, what the CLI's yaml.dump emits)
+    and the nested style (indent=2, common hand-edited / library output)
+    are valid YAML and occur in production, so tests exercise both.
     """
+    pad = " " * indent
     lines = ["wikis:"]
     for w in wikis:
-        lines.append("- id: %s" % w["id"])
-        lines.append("  url: %s" % w["url"])
+        lines.append("%s- id: %s" % (pad, w["id"]))
+        lines.append("%s  url: %s" % (pad, w["url"]))
         if "name" in w:
-            lines.append("  name: %s" % w["name"])
+            lines.append("%s  name: %s" % (pad, w["name"]))
     wikis_yaml.write_text("\n".join(lines) + "\n")
 
 
@@ -99,8 +105,8 @@ def script_runner(workspace):
     """Convenience: returns a callable that writes a wikis.yaml and runs
     the script in one step. The callable returns
     (apache_conf_text, CompletedProcess) so tests can assert on both."""
-    def _run(wikis):
-        write_wikis(workspace["wikis_yaml"], wikis)
+    def _run(wikis, indent=0):
+        write_wikis(workspace["wikis_yaml"], wikis, indent=indent)
         return run_script(workspace)
     _run.workspace = workspace
     return _run

--- a/tests/test_config_subdir_wikis.py
+++ b/tests/test_config_subdir_wikis.py
@@ -7,6 +7,8 @@ These tests run the real script in a temp workspace via subprocess
 and assert on the resulting files.
 """
 
+import pytest
+
 
 class TestApacheRewriteGeneration:
     """The new public_assets rewrite logic added for #144."""
@@ -199,3 +201,39 @@ class TestEdgeCases:
             [{"id": "my_wiki_id", "url": "localhost"}],
         )
         assert "/mediawiki/public_assets/my_wiki_id/" in cfg
+
+
+class TestIndentationTolerance:
+    """wikis.yaml appears in two valid YAML shapes in production: flat
+    block style (list items at column 0, what the CLI's yaml.dump emits)
+    and nested style (list items indented under 'wikis:', common from
+    hand edits or other serializers). The parser must handle both, or an
+    indented file silently yields no rewrite rules and every wiki's
+    /public_assets/ (logos, favicons) 404s. Regression guard for the
+    indented case, which shipped broken.
+    """
+
+    @pytest.mark.parametrize("indent", [0, 2, 4])
+    def test_root_wiki_rewrite_generated_regardless_of_indent(
+        self, script_runner, indent,
+    ):
+        cfg, result = script_runner(
+            [{"id": "main", "url": "canasta.wiki"}], indent=indent,
+        )
+        assert result.returncode == 0, result.stderr
+        assert "RewriteCond %{HTTP_HOST} ^canasta\\.wiki$ [NC]" in cfg
+        assert (
+            "RewriteRule ^/public_assets/(.*)$ "
+            "/mediawiki/public_assets/main/$1 [L]"
+        ) in cfg
+
+    @pytest.mark.parametrize("indent", [0, 2, 4])
+    def test_multi_host_farm_all_wikis_parsed_when_indented(
+        self, script_runner, indent,
+    ):
+        cfg, _ = script_runner([
+            {"id": "canasta", "url": "canasta.wiki", "name": "Canasta Wiki"},
+            {"id": "demo", "url": "demo.canasta.wiki", "name": "demo"},
+        ], indent=indent)
+        assert "/mediawiki/public_assets/canasta/" in cfg
+        assert "/mediawiki/public_assets/demo/" in cfg


### PR DESCRIPTION
## Problem

`config-subdir-wikis.sh` parses `wikis.yaml` with awk anchors pinned to column 0 (`/^- id:/`, `/^  url:/`). A `wikis.yaml` whose list items are indented under `wikis:` — valid YAML, produced by hand edits and some serializers — parses to nothing, so no per-wiki `public_assets` rewrite rules are generated and every wiki's `/public_assets/` (logo, favicon) 404s.

Observed live on a wiki farm: the logo vanished after `config/wikis.yaml` was regenerated in the indented style. The logo files were present on the volume, just unreachable. The test fixture only emitted the column-0 form, so CI stayed green while production broke.

## Fix

- [`config-subdir-wikis.sh`](_sources/scripts/config-subdir-wikis.sh): whitespace-tolerant anchors (`/^[ \t]*-[ \t]+id:/`, `/^[ \t]*url:/`) so both flat block style (column 0) and nested style parse. Field extraction (`$3`/`$2`) already worked regardless of indent.
- Test fixture `write_wikis` gains an `indent` param; new `TestIndentationTolerance` runs a farm at indent 0/2/4. Verified these fail on the old parser (empty config) and pass with the fix.

## Testing

Full suite passes (42 tests).

Fixes #201