### PR TITLE
fix: remove the unused MediaWiki web installer (mw-config) from the image (#213)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -142,12 +142,15 @@ RUN set -x; \
         fi; \
     done
 
-# Cleanup all .git leftovers
+# Cleanup all .git leftovers and the unused MediaWiki web installer.
+# mw-config/ is the web installer UI; Canasta installs via maintenance/install.php
+# (CLI installer), so mw-config/ is dead weight and should not be web-reachable.
 # cd is used within a multi-command && chain
 # hadolint ignore=DL3003
 RUN set -x; \
     cd "$MW_HOME" \
-    && find . \( -name ".git" -o -name ".gitignore" -o -name ".gitmodules" -o -name ".gitattributes" \) -exec rm -rf -- {} +
+    && find . \( -name ".git" -o -name ".gitignore" -o -name ".gitmodules" -o -name ".gitattributes" \) -exec rm -rf -- {} + \
+    && rm -rf mw-config
 
 # Move files around
 RUN set -x; \


### PR DESCRIPTION
Closes #213.

## Problem

MediaWiki's `mw-config/` web installer ships in the image at `/var/www/mediawiki/w/mw-config/` and is reachable over HTTP (`https://<site>/w/mw-config/index.php`, plus farm sub-paths). Nothing blocks the path.

Reinstallation is gated because Canasta ships a real `LocalSettings.php`, so the worst case is capped — but the installer is unnecessary attack surface (and can leak version/environment info), and Canasta never uses it: wikis are installed via the **CLI installer** (`maintenance/install.php` → `includes/installer/`).

## Fix

Delete `mw-config/` during the build, folded into the existing `.git`-leftover cleanup step so no extra image layer is added:

```dockerfile
&& rm -rf mw-config
```

This removes the surface entirely rather than just blocking it at the web layer. The CLI installer is unaffected (it lives in `includes/installer/`, not `mw-config/`); the web-installer bootstrap branch in `CanastaDefaultSettings.php` simply becomes unreachable dead code.