### PR TITLE
Cache-bust the apt-upgrade layer so rebuilds pull current Debian packages

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -160,6 +160,10 @@ jobs:
           echo "CANASTA_VERSION=$CANASTA_VERSION" >> "$GITHUB_OUTPUT"
           echo "IS_RELEASE=$IS_RELEASE" >> "$GITHUB_OUTPUT"
           echo "SHA_SHORT=$SHA_SHORT" >> $GITHUB_OUTPUT
+          # Passed to the build as APT_REFRESH so the apt-upgrade layer's cache key
+          # changes daily; otherwise a rebuild reuses a stale cached layer and never
+          # pulls newer Debian security packages.
+          echo "BDATE=$BDATE" >> $GITHUB_OUTPUT
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -183,6 +187,8 @@ jobs:
           push: true
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          build-args: |
+            APT_REFRESH=${{ steps.generate.outputs.BDATE }}
           tags: ${{ steps.generate.outputs.REGISTRY_TAGS }}
       -
         name: Image digest

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,11 +20,19 @@ ENV MW_VERSION=${MW_VERSION} \
 LABEL wiki.canasta.mediawiki.version="$MW_CORE_VERSION" \
       wiki.canasta.mediawiki.branch="$MW_VERSION"
 
+# Cache-bust the package-refresh layer below so a rebuild actually pulls current
+# Debian security updates instead of reusing a stale cached apt layer. CI passes a
+# value that changes daily (APT_REFRESH build-arg); when it changes, this layer and
+# everything after it rebuild against current mirrors. Referencing it inside the RUN
+# is what makes it part of the layer's cache key.
+ARG APT_REFRESH=unset
+
 # System setup
 # Pinning system package versions is impractical on Debian
 # hadolint ignore=DL3008
 RUN set -x; \
-	apt-get clean \
+	echo "apt refresh token: ${APT_REFRESH}" \
+	&& apt-get clean \
 	&& apt-get update \
 	&& apt-get install -y --no-install-recommends aptitude \
 	&& aptitude -y upgrade \


### PR DESCRIPTION
## Problem

The `apt upgrade` layer in the Dockerfile was served from the GitHub Actions build cache on every build (`cache-from: type=gha`, pinned `FROM debian:12.8`, unchanged instruction), so "rebuild" releases never actually pulled newer Debian security packages — OS packages stayed frozen at whenever that layer was last built uncached.

Evidenced in the 1.3.16 build (run 30160511389): the OS-package layer logged `#16 CACHED`, and the image shipped `imagemagick …deb12u12` even though `deb12u13` (DLA-4696-1) had been published ~29h earlier. A real `apt upgrade` would have pulled it.

## Change

- **Dockerfile:** add `ARG APT_REFRESH`, referenced inside the apt `RUN` so its value becomes part of that layer's cache key.
- **docker-image.yml:** export `BDATE` and pass it as the `APT_REFRESH` build-arg. When the date changes, the apt layer (and everything after it) rebuilds against current Debian mirrors, so a rebuild — and therefore a release — reflects current security state at least daily.

## Cost note

Because busting the apt layer invalidates every layer after it, the first build on any given day is a full rebuild (~20–27 min); same-day builds stay cached. That's an acceptable daily cost for a security base image and is what makes the immutable version tag a genuinely fresh build. If preferred, the bust can instead be scoped to release builds only (gate on `IS_RELEASE`) — happy to adjust.

Fixes #216
