### PR TITLE
Rescan the version tag only (drop redundant rolling tags)

### DIFF
--- a/.github/workflows/rescan-published-images.yml
+++ b/.github/workflows/rescan-published-images.yml
@@ -33,20 +33,14 @@ jobs:
       - name: Determine current tags
         id: tags
         run: |
-          MEDIAWIKI_VERSION=$(sed -nr 's/.*MW_CORE_VERSION=([0-9]+\.[0-9]+\.[0-9]+).*/\1/p' Dockerfile | head -n1)
-          MEDIAWIKI_BRANCH=${MEDIAWIKI_VERSION%.*}
           CANASTA_VERSION=$(cat VERSION)
 
-          if [[ ! "$MEDIAWIKI_BRANCH" =~ ^[0-9]+\.[0-9]+$ ]] ||
-             [[ ! "$CANASTA_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "::error::Could not determine valid published image tags."
+          if [[ ! "$CANASTA_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Could not determine a valid published version tag."
             exit 1
           fi
 
-          {
-            echo "mediawiki=$MEDIAWIKI_BRANCH-latest"
-            echo "version=$CANASTA_VERSION"
-          } >> "$GITHUB_OUTPUT"
+          echo "version=$CANASTA_VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Login to GitHub Container Registry
         env:
@@ -62,7 +56,6 @@ jobs:
       - name: Scan tags and prepare report
         id: scan
         env:
-          MEDIAWIKI_TAG: ${{ steps.tags.outputs.mediawiki }}
           VERSION_TAG: ${{ steps.tags.outputs.version }}
         run: |
           RESULT_DIR="$RUNNER_TEMP/trivy-results"
@@ -73,7 +66,7 @@ jobs:
           : > "$FINDINGS"
           SCANNED=0
 
-          for TAG in latest "$MEDIAWIKI_TAG" "$VERSION_TAG"; do
+          for TAG in "$VERSION_TAG"; do
             INSPECT_ERROR="$RESULT_DIR/inspect-error"
             if ! MANIFEST=$(docker buildx imagetools inspect --raw "$IMAGE:$TAG" 2> "$INSPECT_ERROR"); then
               cat "$INSPECT_ERROR" >&2


### PR DESCRIPTION
## Change

Scan only the immutable version tag (both arches), dropping `latest` and `<MW>-latest`.

- `latest` ≡ `<MW>-latest` — co-pushed from the same build, identical digest, so reporting both added rows without signal.
- Neither rolling tag is what anyone deploys; the version tag is the pinned/released base, and its fixable-CVE count already climbs nightly on its own (frozen image + updating Trivy DB). That climb is the OS-release trigger.

Also drops the now-unneeded MediaWiki-branch derivation (it only existed to build `<MW>-latest`).

`--ignore-unfixed` stays: every CanastaBase finding is an OS package, which is Debian's to fix, so unfixed OS CVEs aren't actionable here. (The unfixed-CRITICAL awareness treatment is Canasta-only, for the extension layer where we have leverage — CanastaWiki/Canasta#674.)

## Validation

Schedule/dispatch-only workflow, so PR CI won't exercise it. Needs a `workflow_dispatch` run after merge to confirm the report renders with the single tag.

Fixes #218
