### PR TITLE
Restore robots.txt User-agent line and load.php allow

### DIFF
--- a/_sources/configs/robots-main.txt
+++ b/_sources/configs/robots-main.txt
@@ -1,3 +1,5 @@
+User-agent: *
+Allow: /w/load.php
 Allow: /w/resources
 Allow: /w/skins
 Allow: /w/extensions


### PR DESCRIPTION
Fixes #223.

`_sources/configs/robots-main.txt` had no `User-agent:` line. Per RFC 9309 §2.1, `Allow`/`Disallow` directives that precede any `User-agent` line belong to no group and are discarded by compliant crawlers, so every rule in the shipped robots.txt has been ignored since March 2024 — including `Disallow: /w/`.

This is a regression, not a policy change. The file was correct when it was added as a static `robots.txt` in the initial commit (`5680da8`, July 2021). https://github.com/CanastaWiki/Canasta/pull/364 renamed it to `robots-main.txt` and rewrote it, adding `Allow: /w/images` and `Allow: /w/sitemap` but dropping `User-agent: *` and `Allow: /w/load.php?`. The `robots.php` added in that same commit never emitted a `User-agent` line either, so nothing in the pipeline supplied it.

Restoring both directives returns the crawl profile Canasta shipped from 2021 until March 2024.

`Allow: /w/load.php` has to land alongside the group header: once `Disallow: /w/` actually takes effect it would otherwise block `load.php`, which serves the CSS and JS search engines need to render pages. The original's trailing `?` is dropped — prefix matching covers the query-string form either way, and without it the bare path matches too.