### PR TITLE
Serve /server-status to loopback over IPv6, and address it numerically

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -266,7 +266,11 @@ COPY _sources/images/Powered-by-Canasta.png /var/www/mediawiki/w/resources/asset
 EXPOSE 80
 WORKDIR $MW_HOME
 
+# 127.0.0.1, not localhost: the name resolves to ::1 first on some
+# runtimes, and wget does not retry the other family once a connection
+# succeeds — so the check reached Apache over IPv6 and got MediaWiki's
+# 404 instead of the status handler.
 HEALTHCHECK --interval=1m --timeout=10s --start-period=5m \
-	CMD wget -q --method=HEAD localhost/server-status
+	CMD wget -q --method=HEAD 127.0.0.1/server-status
 
 CMD ["/run-all.sh"]

--- a/_sources/configs/mediawiki.conf
+++ b/_sources/configs/mediawiki.conf
@@ -3,8 +3,12 @@ DocumentRoot /var/www/mediawiki
 RewriteEngine On
 
 <IfModule mod_status.c>
-    # Allow access to /server-status from localhost
-    <If "%{REMOTE_ADDR} ==  '127.0.0.1' && %{REQUEST_URI} == '/server-status'">
+    # Allow access to /server-status from loopback, in either address
+    # family. A caller arriving over IPv6 has REMOTE_ADDR ::1, and
+    # matching 127.0.0.1 alone sent it through to MediaWiki as a 404 —
+    # which is what the container's own healthcheck did wherever
+    # `localhost` resolved to ::1 first.
+    <If "(%{REMOTE_ADDR} == '127.0.0.1' || %{REMOTE_ADDR} == '::1') && %{REQUEST_URI} == '/server-status'">
         RewriteRule ^/?server-status$ - [END]
         SetHandler server-status
     </If>


### PR DESCRIPTION
The `<If>` guard matched `REMOTE_ADDR` against `'127.0.0.1'` alone, so a caller arriving over IPv6 (`::1`) fell through to MediaWiki instead of the status handler. The image's own `HEALTHCHECK` is such a caller wherever `localhost` resolves to `::1` first — and wget does not retry the other family once a connection succeeds, so it saw MediaWiki's response and failed permanently rather than falling back to IPv4.

Two changes, either of which closes the failure; both are worth making.

- **`mediawiki.conf`** accepts `::1` as well. This is the general repair: any local caller over IPv6 got a 404 today, not only the healthcheck.
- **`Dockerfile`** points the healthcheck at `127.0.0.1`, so it no longer depends on name resolution at all.

## Verified

Against `ghcr.io/canastawiki/canasta:latest` with the patched config mounted in, on a Debian 13 host running rootless podman:

```
                 localhost/server-status   127.0.0.1/server-status
stock            503 (falls through)       200
patched          200                       200
```

Both containers have the same `/etc/hosts` — `localhost` maps to `127.0.0.1` and `::1`. The 503 rather than 404 is because MediaWiki is unconfigured in a bare `apache2ctl` run; the cause is the same, the request reaching MediaWiki instead of the status handler.

`apache2ctl -t` reports `Syntax OK` with the parenthesized expression, matching the stock control.

## Scope note

This is latent on podman today: the published image is OCI-format and podman ignores `Healthcheck` there, so no check runs at all. It is live anywhere a runtime does read the healthcheck and resolves `localhost` to `::1`. Docker resolves to IPv4, which is why this has never been visible in CI.

Canasta-CLI does not depend on this being fixed — CanastaWiki/Canasta-CLI#1359 gets its readiness signal by making the request itself. This is about the image being correct on its own.

## Risk

`canasta create` on Docker waits on this healthcheck. The change should be inert there, since Docker already resolves `localhost` to IPv4 — but that is an argument from reasoning, not a test. The Canasta-CLI integration suite is what would prove it, and it does not run against a CanastaBase branch automatically. Worth building this branch and running a create against it before merge if you want that covered.

Closes #226
