### PR TITLE
Resolve wiki directory logos server-side

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -70,5 +70,10 @@ jobs:
           python -m venv .venv
           .venv/bin/pip install -r requirements-test.txt
 
+      # The CanastaFarm404.php tests render the page through php and skip
+      # when it is absent, so fail here rather than skipping silently.
+      - name: Check for php
+        run: php --version
+
       - name: Run tests
         run: .venv/bin/pytest tests/ -v

--- a/_sources/canasta/CanastaFarm404.php
+++ b/_sources/canasta/CanastaFarm404.php
@@ -9,6 +9,11 @@
  * Variables in scope from the caller: $wikiConfigurations, $urlComponents, $path,
  * $directoryOnly.
  *
+ * Wiki logos are resolved server-side from public_assets/<wiki_id>/logo.<ext>,
+ * which the web server grants anonymously regardless of the wiki's read
+ * permissions. Wikis without such a file fall back to a client-side siteinfo
+ * lookup, which only works when the wiki is publicly readable.
+ *
  * In 404 mode, the directory is shown only when CANASTA_ENABLE_WIKI_DIRECTORY is "true".
  * In directory mode, the directory is always shown (the caller already checked the env var).
  */
@@ -18,6 +23,44 @@ $showDirectory = $directoryOnly || ( getenv( 'CANASTA_ENABLE_WIKI_DIRECTORY' ) =
 $scheme = parse_url( getenv( 'MW_SITE_SERVER' ) ?: 'https://localhost', PHP_URL_SCHEME ) ?: 'https';
 $requestedPath = isset( $urlComponents['path'] ) ? htmlspecialchars( $urlComponents['path'], ENT_QUOTES, 'UTF-8' ) : '/';
 $pageTitle = $directoryOnly ? 'Wiki Directory' : 'Page Not Found';
+
+$publicAssetsRoot = getenv( 'MW_VOLUME' ) ? rtrim( getenv( 'MW_VOLUME' ), '/' ) . '/public_assets' : '';
+
+// Extensions accepted for a conventional logo, in the order they win when a
+// wiki has more than one.
+$logoExtensions = [ 'svg', 'png', 'webp', 'jpg', 'jpeg', 'gif' ];
+
+/**
+ * Find a wiki's conventional logo file name, or null when it has none.
+ * The wiki ID is used as a path segment, so anything that could escape the
+ * public_assets root is rejected rather than sanitized.
+ */
+$findWikiLogo = static function ( $wikiId ) use ( $publicAssetsRoot, $logoExtensions ) {
+	if ( $publicAssetsRoot === '' || $wikiId === '' || preg_match( '#[/\\\\]|^\.#', $wikiId ) ) {
+		return null;
+	}
+	$entries = @scandir( $publicAssetsRoot . '/' . $wikiId );
+	if ( $entries === false ) {
+		return null;
+	}
+	// The name is matched case-insensitively; scandir sorts, so when a wiki
+	// holds both "Logo.png" and "logo.png" the first in sorted order wins.
+	$byExtension = [];
+	foreach ( $entries as $entry ) {
+		if ( preg_match( '/^logo\.([A-Za-z]+)$/i', $entry, $m ) ) {
+			$extension = strtolower( $m[1] );
+			if ( !isset( $byExtension[$extension] ) ) {
+				$byExtension[$extension] = $entry;
+			}
+		}
+	}
+	foreach ( $logoExtensions as $extension ) {
+		if ( isset( $byExtension[$extension] ) ) {
+			return $byExtension[$extension];
+		}
+	}
+	return null;
+};
 
 ?><!DOCTYPE html>
 <html lang="en">
@@ -39,7 +82,8 @@ body{margin:0;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Hel
 .wiki-card:hover{box-shadow:0 2px 8px rgba(0,0,0,.12)}
 .wiki-card a{display:block;text-decoration:none;color:inherit;padding:20px;text-align:center}
 .wiki-card .logo{width:80px;height:80px;margin:0 auto 12px;display:flex;align-items:center;justify-content:center}
-.wiki-card .logo img{max-width:80px;max-height:80px;display:none}
+.wiki-card .logo img{max-width:80px;max-height:80px}
+.wiki-card .logo img[data-api]{display:none}
 .wiki-card .name{font-size:16px;font-weight:600;color:#0645ad}
 </style>
 </head>
@@ -56,13 +100,19 @@ body{margin:0;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Hel
     <h2>Available wikis</h2>
     <div class="wiki-grid">
 <?php foreach ( $wikiConfigurations['wikis'] as $wiki ):
+	$rawWikiId = (string)( $wiki['id'] ?? '' );
+	$rawWikiUrl = $scheme . '://' . (string)( $wiki['url'] ?? '' );
 	$wikiName = htmlspecialchars( $wiki['name'] ?? $wiki['id'] ?? 'Wiki', ENT_QUOTES, 'UTF-8' );
-	$wikiUrl = $scheme . '://' . htmlspecialchars( $wiki['url'] ?? '', ENT_QUOTES, 'UTF-8' );
-	$wikiId = htmlspecialchars( $wiki['id'] ?? '', ENT_QUOTES, 'UTF-8' );
+	$wikiUrl = htmlspecialchars( $rawWikiUrl, ENT_QUOTES, 'UTF-8' );
+	$wikiId = htmlspecialchars( $rawWikiId, ENT_QUOTES, 'UTF-8' );
+	$logoFile = $findWikiLogo( $rawWikiId );
+	$logoAttr = $logoFile !== null
+		? 'src="' . htmlspecialchars( $rawWikiUrl . '/public_assets/' . rawurlencode( $logoFile ), ENT_QUOTES, 'UTF-8' ) . '"'
+		: 'data-api="' . $wikiUrl . '/w/api.php"';
 ?>
       <div class="wiki-card">
         <a href="<?php echo $wikiUrl; ?>">
-          <div class="logo"><img alt="" data-wiki-id="<?php echo $wikiId; ?>" data-api="<?php echo $wikiUrl; ?>/w/api.php"></div>
+          <div class="logo"><img alt="" data-wiki-id="<?php echo $wikiId; ?>" <?php echo $logoAttr; ?>></div>
           <div class="name"><?php echo $wikiName; ?></div>
         </a>
       </div>
@@ -70,6 +120,19 @@ body{margin:0;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Hel
     </div>
   </div>
 <script>
+// A server-resolved logo file can still fail to load — a wiki added to
+// wikis.yaml since the last restart has no public_assets rewrite yet.
+// Hide those rather than leaving a broken-image glyph in the card.
+document.querySelectorAll('.wiki-card img[src]').forEach(function(img) {
+  var hide = function() {
+    img.style.display = 'none';
+  };
+  if (img.complete && img.naturalWidth === 0) {
+    hide();
+    return;
+  }
+  img.addEventListener('error', hide);
+});
 document.querySelectorAll('.wiki-card img[data-api]').forEach(function(img) {
   var url = img.getAttribute('data-api') +
     '?action=query&meta=siteinfo&siprop=general&format=json&origin=*';

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 """Shared fixtures for CanastaBase tests."""
 
+import json
 import os
 import subprocess
 
@@ -110,3 +111,61 @@ def script_runner(workspace):
         return run_script(workspace)
     _run.workspace = workspace
     return _run
+
+
+FARM_404 = os.path.join(REPO_ROOT, "_sources", "canasta", "CanastaFarm404.php")
+
+# CanastaFarm404.php is normally required by FarmConfigLoader.php with
+# $wikiConfigurations / $urlComponents / $directoryOnly already in scope.
+# This harness reproduces that calling convention outside MediaWiki.
+FARM_404_HARNESS = """<?php
+$wikiConfigurations = json_decode( file_get_contents( $argv[1] ), true );
+$urlComponents = [ 'path' => $argv[2] ];
+$path = '';
+$directoryOnly = $argv[3] === '1';
+require getenv( 'FARM_404_PHP' );
+"""
+
+
+@pytest.fixture
+def farm_page(tmp_path):
+    """Render CanastaFarm404.php through the real php binary and return
+    the HTML.
+
+    The callable takes the wikis list that would come from wikis.yaml,
+    an optional {wiki_id: [filenames]} map of files to create under
+    public_assets/<wiki_id>/, and the directory/404 mode flag.
+    """
+    mw_volume = tmp_path / "farm-mediawiki"
+    (mw_volume / "public_assets").mkdir(parents=True)
+    harness = tmp_path / "render_farm_404.php"
+    harness.write_text(FARM_404_HARNESS)
+
+    def _render(wikis, assets=None, directory_only=True, site_server="https://example.com"):
+        for wiki_id, filenames in (assets or {}).items():
+            asset_dir = mw_volume / "public_assets" / wiki_id
+            asset_dir.mkdir(parents=True, exist_ok=True)
+            for filename in filenames:
+                (asset_dir / filename).write_bytes(b"")
+        config = tmp_path / "wikis.json"
+        config.write_text(json.dumps({"wikis": wikis}))
+        env = os.environ.copy()
+        env.update({
+            "FARM_404_PHP": FARM_404,
+            "MW_VOLUME": str(mw_volume),
+            "MW_SITE_SERVER": site_server,
+            "CANASTA_ENABLE_WIKI_DIRECTORY": "true",
+        })
+        result = subprocess.run(
+            ["php", str(harness), str(config), "/missing",
+             "1" if directory_only else "0"],
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, result.stderr
+        assert result.stderr == "", result.stderr
+        return result.stdout
+
+    _render.mw_volume = mw_volume
+    return _render

--- a/tests/test_farm_404_directory.py
+++ b/tests/test_farm_404_directory.py
@@ -1,0 +1,130 @@
+"""Tests for _sources/canasta/CanastaFarm404.php.
+
+The wiki directory resolves each card's logo from
+public_assets/<wiki_id>/logo.<ext>, which the web server grants
+anonymously, and only falls back to the client-side siteinfo lookup when
+a wiki has no such file. These tests render the real page through php.
+"""
+
+import shutil
+
+import pytest
+
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("php") is None,
+    reason="php is required to render CanastaFarm404.php",
+)
+
+
+class TestServerSideLogoResolution:
+    """Private wikis get a logo without an anonymous API call (#230)."""
+
+    def test_logo_file_becomes_a_src(self, farm_page):
+        html = farm_page(
+            [{"id": "main", "url": "example.com", "name": "Main"}],
+            assets={"main": ["logo.png"]},
+        )
+        assert 'src="https://example.com/public_assets/logo.png"' in html
+        assert "data-api=" not in html
+
+    def test_subdir_wiki_logo_url_keeps_the_path(self, farm_page):
+        html = farm_page(
+            [{"id": "docs", "url": "example.com/docs", "name": "Docs"}],
+            assets={"docs": ["logo.svg"]},
+        )
+        assert 'src="https://example.com/docs/public_assets/logo.svg"' in html
+
+    def test_wiki_without_a_logo_file_keeps_the_api_fallback(self, farm_page):
+        html = farm_page([{"id": "main", "url": "example.com", "name": "Main"}])
+        assert 'data-api="https://example.com/w/api.php"' in html
+        assert "src=" not in html
+
+    def test_only_the_wiki_without_a_logo_falls_back(self, farm_page):
+        html = farm_page(
+            [
+                {"id": "main", "url": "example.com", "name": "Main"},
+                {"id": "docs", "url": "example.com/docs", "name": "Docs"},
+            ],
+            assets={"main": ["logo.png"]},
+        )
+        assert 'src="https://example.com/public_assets/logo.png"' in html
+        assert 'data-api="https://example.com/docs/w/api.php"' in html
+
+    def test_svg_wins_over_png(self, farm_page):
+        html = farm_page(
+            [{"id": "main", "url": "example.com"}],
+            assets={"main": ["logo.png", "logo.svg"]},
+        )
+        assert 'src="https://example.com/public_assets/logo.svg"' in html
+        assert "logo.png" not in html
+
+    def test_capitalized_name_and_extension_are_matched(self, farm_page):
+        html = farm_page(
+            [{"id": "main", "url": "example.com"}],
+            assets={"main": ["Logo.PNG"]},
+        )
+        assert 'src="https://example.com/public_assets/Logo.PNG"' in html
+
+    def test_unrelated_asset_files_are_ignored(self, farm_page):
+        html = farm_page(
+            [{"id": "main", "url": "example.com"}],
+            assets={"main": ["favicon.ico", "logo-wide.png", "mylogo.png"]},
+        )
+        assert "src=" not in html
+        assert 'data-api="https://example.com/w/api.php"' in html
+
+    def test_logos_also_render_on_the_404_page(self, farm_page):
+        html = farm_page(
+            [{"id": "main", "url": "example.com"}],
+            assets={"main": ["logo.png"]},
+            directory_only=False,
+        )
+        assert "404" in html
+        assert 'src="https://example.com/public_assets/logo.png"' in html
+
+    def test_http_scheme_is_carried_into_the_logo_url(self, farm_page):
+        html = farm_page(
+            [{"id": "main", "url": "localhost:8080"}],
+            assets={"main": ["logo.png"]},
+            site_server="http://localhost:8080",
+        )
+        assert 'src="http://localhost:8080/public_assets/logo.png"' in html
+
+
+class TestLogoLookupSafety:
+    """The wiki ID is used as a path segment, and wikis.yaml is hand-editable."""
+
+    def test_wiki_id_with_a_traversal_segment_is_refused(self, farm_page):
+        (farm_page.mw_volume / "public_assets" / "victim").mkdir(parents=True)
+        (farm_page.mw_volume / "public_assets" / "victim" / "logo.png").write_bytes(b"")
+        html = farm_page([{"id": "../public_assets/victim", "url": "example.com"}])
+        assert "src=" not in html
+
+    def test_wiki_id_with_a_leading_dot_is_refused(self, farm_page):
+        html = farm_page(
+            [{"id": ".hidden", "url": "example.com"}],
+            assets={".hidden": ["logo.png"]},
+        )
+        assert "src=" not in html
+
+    def test_missing_wiki_id_falls_back_without_error(self, farm_page):
+        html = farm_page([{"url": "example.com", "name": "Main"}])
+        assert 'data-api="https://example.com/w/api.php"' in html
+
+
+class TestDirectoryMarkup:
+    """The stylesheet must not hide a logo the server already resolved."""
+
+    def test_only_the_api_placeholder_starts_hidden(self, farm_page):
+        html = farm_page([{"id": "main", "url": "example.com"}])
+        assert ".wiki-card .logo img[data-api]{display:none}" in html
+        assert ".wiki-card .logo img{max-width:80px;max-height:80px}" in html
+
+    def test_wiki_name_and_link_still_render(self, farm_page):
+        html = farm_page(
+            [{"id": "main", "url": "example.com", "name": "Main Wiki"}],
+            assets={"main": ["logo.png"]},
+        )
+        assert '<a href="https://example.com">' in html
+        assert "Main Wiki" in html


### PR DESCRIPTION
Fixes #230.

## Problem

The wiki directory emitted a placeholder `<img>` per card and resolved its source
in the browser:

```js
var url = img.getAttribute('data-api') +
  '?action=query&meta=siteinfo&siprop=general&format=json&origin=*';
```

That request carries no session. A wiki with `$wgGroupPermissions['*']['read'] = false`
answers `readapidenied`, so `query.general.logo` is undefined, the handler returns
early, and the `<img>` keeps its `display:none`. Every card on a private farm is
logo-less.

## Fix

Resolve the logo while rendering the page instead. For wiki `<id>`, scan
`$MW_VOLUME/public_assets/<id>/` for a `logo.<ext>` file and emit
`<wikiUrl>/public_assets/<file>` as a real `src`.

`public_assets` is served with `Require all granted` and has a per-wiki rewrite
generated by `config-subdir-wikis.sh`, so it is reachable regardless of the wiki's
read permissions — and the card needs no JavaScript at all.

Details:

- The name is matched case-insensitively; `svg` > `png` > `webp` > `jpg` > `jpeg` >
  `gif` when a wiki has more than one.
- A wiki with no such file keeps the existing `data-api` siteinfo probe, so public
  farms that never configured anything behave exactly as before.
- The stylesheet now hides only `img[data-api]` instead of every logo image.
- A server-resolved logo that fails to load (a wiki added to `wikis.yaml` since the
  last restart has no rewrite yet) is hidden rather than left as a broken-image glyph.
- The wiki ID becomes a path segment and `wikis.yaml` is hand-editable, so an ID
  containing a slash, backslash, or leading dot is refused rather than sanitized.

## Tests

New `tests/test_farm_404_directory.py` renders the real page through `php` via a
`farm_page` fixture — the first PHP coverage in this repo. 14 tests covering
file-to-src, sub-path wiki URLs, mixed farms, extension precedence, capitalized
names, near-miss filenames (`logo-wide.png`, `mylogo.png`), 404 mode, the `http`
scheme, the traversal guards, and the stylesheet rule. Full suite: 59 passed.

The tests skip when `php` is unavailable, so the unit job gained a `php --version`
step — otherwise they would skip silently in CI.

## Follow-up

The `public_assets/<id>/logo.<ext>` convention needs a page on canasta.wiki,
including how to keep a logo out of the directory by storing it under another name
or in the images directory.
